### PR TITLE
The dialyze rule now only analyzes the target and not its deps

### DIFF
--- a/ct.bzl
+++ b/ct.bzl
@@ -15,7 +15,7 @@ def additional_file_dest_relative_path(dep_label, f):
     return _additional_file_dest_relative_path(dep_label, f)
 
 def code_paths(ctx, dep):
-    return _code_paths(ctx, dep)
+    return _code_paths(dep)
 
 def sanitize_sname(s):
     return _sanitize_sname(s)

--- a/private/ct.bzl
+++ b/private/ct.bzl
@@ -28,7 +28,7 @@ def _unique_short_dirnames(files):
             dirs.append(dirname)
     return dirs
 
-def code_paths(ctx, dep):
+def code_paths(dep):
     return [
         path_join(dep.label.workspace_root, d) if dep.label.workspace_root != "" else d
         for d in _unique_short_dirnames(dep[ErlangAppInfo].beam)

--- a/private/erlc.bzl
+++ b/private/erlc.bzl
@@ -11,7 +11,7 @@ def beam_file(ctx, src, dir):
     name = src.basename.replace(".erl", ".beam")
     return ctx.actions.declare_file(path_join(dir, name))
 
-def _unique_dirnames(files):
+def unique_dirnames(files):
     dirs = []
     for f in files:
         dirname = f.path if f.is_directory else f.dirname
@@ -29,19 +29,19 @@ def _impl(ctx):
     erl_args = ctx.actions.args()
     erl_args.add("-v")
 
-    for dir in _unique_dirnames(ctx.files.hdrs):
+    for dir in unique_dirnames(ctx.files.hdrs):
         erl_args.add("-I", dir)
 
     for dep in ctx.attr.deps:
         lib_info = dep[ErlangAppInfo]
         if lib_info.erlang_version != erlang_version:
             fail("Mismatched erlang versions", erlang_version, lib_info.erlang_version)
-        for dir in _unique_dirnames(lib_info.include):
+        for dir in unique_dirnames(lib_info.include):
             erl_args.add("-I", path_join(dir, "../.."))
-        for dir in _unique_dirnames(lib_info.beam):
+        for dir in unique_dirnames(lib_info.beam):
             erl_args.add("-pa", dir)
 
-    for dir in _unique_dirnames(ctx.files.beam):
+    for dir in unique_dirnames(ctx.files.beam):
         erl_args.add("-pa", dir)
 
     erl_args.add("-o", dest_dir)

--- a/private/xref.bzl
+++ b/private/xref.bzl
@@ -34,7 +34,7 @@ def _impl(ctx):
     dirs = [path_join(ctx.attr.target.label.package, "ebin")]
     for dep in lib_info.deps + ctx.attr.additional_libs:
         if dep.label.workspace_root != "":
-            extra_paths.extend(code_paths(ctx, dep))
+            extra_paths.extend(code_paths(dep))
         else:
             dirs.append(path_join(dep.label.package, "ebin"))
 


### PR DESCRIPTION
The dialyze rule no longer analyzes the deps of the target. This was probably not desired to begin with but went unnoticed before the introduction of the warnings_as_errors attribute. A new attribute has been added to the plt rule, `deps`, so that information for the dialyzer about those deps can be fed to the dialyze rule. The transitive deps are now included in that process as well.

This is not a breaking change in the API, but depending on usage, will probably cause `bazel test`s that use dialyze to fail without adding the deps to the plt