### PR TITLE
Remove -Wrace_conditions from the default dialyzer options

### DIFF
--- a/private/dialyze.bzl
+++ b/private/dialyze.bzl
@@ -119,7 +119,6 @@ dialyze_test = rule(
         "dialyzer_opts": attr.string_list(
             default = [
                 "-Werror_handling",
-                "-Wrace_conditions",
                 "-Wunmatched_returns",
             ],
         ),


### PR DESCRIPTION
As it is no longer supported in otp 25

Fixes #27 