### PR TITLE
Various enhancements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,3 +80,39 @@ jobs:
     #!   with:
     #!     name: bazel-testlogs-${{matrix.otp}}
     #!     path: ${{ steps.resolve-test-logs-path.outputs.LOGS_PATH }}
+  test-bzlmod:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        otp:
+        - "23.3"
+        - "24.2"
+    steps:
+    - name: CHECKOUT
+      uses: actions/checkout@v2
+    - name: CONFIGURE ERLANG
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ matrix.otp }}
+    - name: CONFIGURE BAZEL
+      run: |
+        ERLANG_HOME="$(dirname $(dirname $(which erl)))"
+        cat << EOF >> .bazelrc
+          build --//:erlang_version=${{ matrix.otp }}
+          build --//:erlang_home=${ERLANG_HOME}
+
+          build --incompatible_strict_action_env
+        EOF
+    - name: TEST
+      run: |
+        bazelisk test //... --experimental_enable_bzlmod
+    - name: RESOVLE TEST LOGS PATH
+      run: |
+        echo "::set-output name=LOGS_PATH::$(readlink -f bazel-testlogs)"
+      id: resolve-test-logs-path
+    - name: CAPTURE TEST LOGS
+      uses: actions/upload-artifact@v2
+      with:
+        name: bazel-testlogs-bzlmod-${{matrix.otp}}
+        path: ${{ steps.resolve-test-logs-path.outputs.LOGS_PATH }}/*

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_erlang",
-    version = "2.4.0",
+    version = "2.5.0",
     compatibility_level = 2,
 )
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The example below follows this convention.
 ```starlark
 http_archive(
     name = "rules_erlang",
-    sha256 = "a58ab84733ed3b43eda6a1c624edf04a0dac7cabdd2b4fcf84391ee8af969965",
-    strip_prefix = "rules_erlang-2.2.1",
-    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/tags/2.2.1.zip"],
+    sha256 = "56569bf2d161ee5007e17bc77919df4d83696cd7ad8ff9be5202751cad3332fd",
+    strip_prefix = "rules_erlang-2.4.0",
+    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/tags/2.4.0.zip"],
 )
 
 load("@rules_erlang//:rules_erlang.bzl", "rules_erlang_dependencies")

--- a/app_file.bzl
+++ b/app_file.bzl
@@ -1,4 +1,12 @@
 load("//private:app_file.bzl", "app_file_private")
 
+_stamp_condition = str(Label("//private:private_stamp_detect"))
+
 def app_file(**kwargs):
-    app_file_private(**kwargs)
+    app_file_private(
+        private_stamp_detect = select({
+            _stamp_condition: True,
+            "//conditions:default": False,
+        }),
+        **kwargs
+    )

--- a/app_file_tool/BUILD.bazel
+++ b/app_file_tool/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//private:erlc.bzl", "erlc_private")
+load("//:erl_eval.bzl", "erl_eval")
+
+erlc_private(
+    name = "beam",
+    srcs = [
+        "src/app_file_tool.erl",
+    ],
+)
+
+erl_eval(
+    name = "escript",
+    srcs = [
+        ":beam",
+    ],
+    outs = [
+        "escript/app_file_tool",
+    ],
+    expression = """
+io:format("Assembiling app_file_tool escript...~n", []),
+Beam = os:getenv("SRCS"),
+Dest = os:getenv("OUTS"),
+ok = escript:create(Dest,
+                    [shebang, comment,
+                     {beam, Beam}]),
+io:format("done.~n", []),
+halt().
+""",
+    visibility = ["//visibility:public"],
+)

--- a/app_file_tool/src/app_file_tool.erl
+++ b/app_file_tool/src/app_file_tool.erl
@@ -1,0 +1,31 @@
+-module(app_file_tool).
+
+-mode(compile).
+
+-export([main/1]).
+
+-spec main([string()]) -> no_return().
+main([KeyString, ValueString, AppSrc]) ->
+    % io:format(standard_error, "~p -> ~p~n", [KeyString, ValueString]),
+    Key = parse_basic(KeyString),
+    Value = parse_basic(ValueString),
+    % io:format(standard_error, "~p -> ~p~n", [Key, Value]),
+    {ok, [AppInfo]} = file:consult(AppSrc),
+    {application, AppName, Props} = AppInfo,
+    NewProps = lists:keystore(Key, 1, Props, {Key, Value}),
+    io:format("~tp.~n", [{application, AppName, NewProps}]),
+    halt();
+main([EntriesString, AppSrc]) ->
+    Entries = parse_basic(EntriesString),
+    {ok, [AppInfo]} = file:consult(AppSrc),
+    {application, AppName, Props} = AppInfo,
+    NewProps = Props ++ Entries,
+    io:format("~tp.~n", [{application, AppName, NewProps}]),
+    halt();
+main(_) ->
+    halt(1).
+
+parse_basic(String) ->
+    {ok, S1, _} = erl_scan:string(String ++ "."),
+    {ok, R} = erl_parse:parse_term(S1),
+    R.

--- a/bzlmod/extensions.bzl
+++ b/bzlmod/extensions.bzl
@@ -377,6 +377,7 @@ $(foreach dep,$(LOCAL_DEPS),        "$(dep)",\n)    ],
 $(foreach dep,$(BUILD_DEPS),        "@$(dep)//:erlang_app",\n)    ],
     deps = [
 $(foreach dep,$(DEPS),        "@$(dep)//:erlang_app",\n)    ],
+    stamp = 0,
 )
 endef
 
@@ -409,6 +410,7 @@ erlang_app(
         "+debug_info",
     ],
     deps = {deps},
+    stamp = 0,
 )
 EOF
         fi
@@ -428,6 +430,7 @@ erlang_app(
         "+deterministic",
         "+debug_info",
     ],
+    stamp = 0,
 )
 EOF
     fi
@@ -444,6 +447,7 @@ erlang_app(
         "+deterministic",
         "+debug_info",
     ],
+    stamp = 0,
 )
 EOF
 fi

--- a/bzlmod/extensions.bzl
+++ b/bzlmod/extensions.bzl
@@ -1,4 +1,17 @@
 load("//:rules_erlang.bzl", "rules_erlang_dependencies")
+load("//:hex_archive.bzl", "hex_archive")
+load(
+    ":hex_pm.bzl",
+    "hex_package_info",
+    "hex_release_info",
+    "newest",
+    "satisfies",
+)
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+    "new_git_repository",
+)
 
 def _download_xrefr(ctx):
     rules_erlang_dependencies()
@@ -6,3 +19,430 @@ def _download_xrefr(ctx):
 download_xrefr = module_extension(
     implementation = _download_xrefr,
 )
+
+HexPackage = provider(fields = [
+    "name",
+    "version",
+    "sha256",
+    "build_file_content",
+    "patch_cmds",
+    "deps",
+    "requirements",
+    "f_fetch",
+])
+
+GitPackage = provider(fields = [
+    "name",
+    "version",
+    "remote",
+    "repository",
+    "branch",
+    "tag",
+    "commit",
+    "build_file_content",
+    "patch_cmds",
+    "f_fetch",
+])
+
+_RESOLVE_MAX_PASSES = 500
+
+def _hex_package_repo(hex_package):
+    if hex_package.build_file_content != "":
+        hex_archive(
+            name = hex_package.name,
+            package_name = hex_package.name,
+            version = hex_package.version,
+            sha256 = hex_package.sha256,
+            build_file_content = hex_package.build_file_content,
+            patch_cmds = hex_package.patch_cmds,
+        )
+    else:
+        if hex_package.deps != None:
+            deps = ["@{}//:erlang_app".format(d) for d in hex_package.deps]
+        else:
+            deps = ""
+
+        hex_archive(
+            name = hex_package.name,
+            package_name = hex_package.name,
+            version = hex_package.version,
+            sha256 = hex_package.sha256,
+            patch_cmds = hex_package.patch_cmds + [PATCH_AUTO_BUILD_BAZEL.format(
+                name = hex_package.name,
+                version = hex_package.version,
+                deps = deps,
+            )],
+        )
+
+def _git_package_repo(git_package):
+    if git_package.build_file_content != "":
+        new_git_repository(
+            name = git_package.name,
+            remote = git_package.remote,
+            branch = git_package.branch,
+            tag = git_package.tag,
+            commit = git_package.commit,
+            build_file_content = git_package.build_file_content,
+            patch_cmds = git_package.patch_cmds,
+        )
+    else:
+        git_repository(
+            name = git_package.name,
+            remote = git_package.remote,
+            branch = git_package.branch,
+            tag = git_package.tag,
+            commit = git_package.commit,
+            patch_cmds = git_package.patch_cmds + [PATCH_AUTO_BUILD_BAZEL.format(
+                name = git_package.name,
+                version = "",
+                deps = [],
+            )],
+        )
+
+def _hex_tree(ctx, name, version):
+    _log(ctx, "Fetching release info for {}@{} from hex.pm".format(name, version))
+    release_info = hex_release_info(ctx, name, version)
+
+    sha256 = release_info["checksum"]
+
+    deps = []
+    requirements = []
+    for (_, props) in release_info["requirements"].items():
+        if not props["optional"]:
+            deps.append(props["app"])
+            requirements.append(props)
+
+    return HexPackage(
+        name = name,
+        version = version,
+        sha256 = sha256,
+        build_file_content = "",
+        patch_cmds = [],
+        deps = deps,
+        requirements = requirements,
+        f_fetch = _hex_package_repo,
+    )
+
+def _hex_package(
+        ctx,
+        name = None,
+        version = None,
+        sha256 = None,
+        build_file_content = None,
+        patch_cmds = None):
+    return HexPackage(
+        name = name,
+        version = version,
+        sha256 = sha256,
+        build_file_content = build_file_content,
+        patch_cmds = patch_cmds,
+        deps = None,
+        requirements = [],
+        f_fetch = _hex_package_repo,
+    )
+
+def _infer_app_name(remote):
+    (_, _, repo) = remote.rpartition("/")
+    if repo == remote:
+        fail("Could not extract erlang app name from {}".format(remote))
+    if not repo.endswith(".git"):
+        fail("Could not extract erlang app name from {}".format(remote))
+    return repo[0:-4]
+
+def _git_package(ctx, dep):
+    if dep.remote != "" and dep.repository != "":
+        fail("'remote' and 'repository' are mutually exclusive options")
+
+    if dep.repository != "":
+        remote = "https://github.com/{}.git".format(dep.repository)
+    elif dep.remote != "":
+        remote = dep.remote
+    else:
+        fail("either 'remote' or 'repository' are required")
+
+    if dep.name != "":
+        name = dep.name
+    else:
+        name = _infer_app_name(remote)
+
+    if dep.commit != "":
+        version = dep.commit
+    elif dep.tag != "":
+        version = dep.tag
+    else:
+        version = dep.branch
+
+    return GitPackage(
+        name = name,
+        version = version,
+        remote = remote,
+        branch = dep.branch,
+        tag = dep.tag,
+        commit = dep.commit,
+        build_file_content = dep.build_file_content,
+        patch_cmds = dep.patch_cmds,
+        f_fetch = _git_package_repo,
+    )
+
+def _without_requirement(name, package):
+    requirements = getattr(package, "requirements", [])
+    if len(requirements) == 0:
+        return package
+    else:
+        # currently only HexPackage has "requirements", so we
+        # can always return one
+        new_requirements = []
+        for r in requirements:
+            if r["app"] != name:
+                new_requirements.append(r)
+
+        return HexPackage(
+            name = package.name,
+            version = package.version,
+            sha256 = package.sha256,
+            build_file_content = package.build_file_content,
+            patch_cmds = package.patch_cmds,
+            deps = package.deps,
+            requirements = new_requirements,
+            f_fetch = package.f_fetch,
+        )
+
+def _log(ctx, msg):
+    ctx.execute([ctx.which("echo"), "RULES_ERLANG: " + msg], timeout = 1, quiet = False)
+
+def _resolve_pass(ctx, packages):
+    all_requirements = []
+    for p in packages:
+        # print("checking reqs for", p.name)
+        all_requirements.extend(getattr(p, "requirements", []))
+    if len(all_requirements) == 0:
+        # no unmet requirements, end recursion
+        return (True, packages)
+    else:
+        # at least one unmet requirement exists...
+        name = all_requirements[0]["app"]
+        requirements = []
+        for r in all_requirements:
+            if r["app"] == name:
+                requirements.append(r["requirement"])
+        requirers = []
+        for p in packages:
+            for r in getattr(p, "requirements", []):
+                if r["app"] == name:
+                    requirers.append(p.name)
+
+        # check if it's already in our package list
+        for p in packages:
+            if p.name == name:
+                if not all([satisfies(p.version, r) for r in requirements]):
+                    _log(ctx, "Ignoring conflicting requirements for {}, {} does not satisfy {} as required by {}".format(
+                        name,
+                        p.version,
+                        requirements,
+                        requirers,
+                    ))
+                return (False, [_without_requirement(name, p) for p in packages])
+
+        # check if a version exists on hex
+        _log(ctx, "Fetching package info for {} from hex.pm".format(name))
+        package_info = hex_package_info(ctx, name)
+        for release in package_info["releases"]:
+            if all([satisfies(release["version"], r) for r in requirements]):
+                _log(ctx, "Using {}@{} required by {} satisfying {}".format(
+                    name,
+                    release["version"],
+                    requirers,
+                    requirements,
+                ))
+                hp = _hex_package(ctx, name, release["version"], "", "")
+                return (False, [_without_requirement(name, p) for p in packages] + [hp])
+
+        fail("Unable to find a version of {} satisfying".format(name), requirements)
+
+def _resolve_hex_pm(ctx, packages):
+    resolved = packages
+    for i in range(0, _RESOLVE_MAX_PASSES):
+        (done, resolved) = _resolve_pass(ctx, resolved)
+        if done:
+            return resolved
+    fail("Dependencies were not resolved after {} passes.".format(_RESOLVE_MAX_PASSES))
+
+def _resolve_local(packages):
+    deduped = []
+    packages_by_name = {}
+    for p in packages:
+        if p.name in packages_by_name:
+            packages_by_name[p.name].append(p)
+        else:
+            packages_by_name[p.name] = [p]
+    for (_, dupes) in packages_by_name.items():
+        p = dupes[0]
+        for dupe in dupes[1:]:
+            p = newest(p, dupe)
+        deduped.append(p)
+    return deduped
+
+def _erlang_package(ctx):
+    packages = []
+    for mod in ctx.modules:
+        for dep in mod.tags.hex_tree:
+            packages.append(_hex_tree(ctx, dep.name, dep.version))
+        for dep in mod.tags.hex:
+            packages.append(_hex_package(
+                ctx,
+                name = dep.name,
+                version = dep.version,
+                sha256 = dep.sha256,
+                build_file_content = dep.build_file_content,
+                patch_cmds = dep.patch_cmds,
+            ))
+        for dep in mod.tags.git:
+            packages.append(_git_package(ctx, dep))
+
+    deduped = _resolve_local(packages)
+
+    resolved = _resolve_hex_pm(ctx, deduped)
+
+    _log(ctx, "Final package list:")
+    for p in resolved:
+        _log(ctx, "    {}@{}".format(p.name, p.version))
+
+    for p in resolved:
+        p.f_fetch(p)
+
+hex_tree = tag_class(attrs = {
+    "name": attr.string(mandatory = True),
+    "version": attr.string(mandatory = True),
+})
+
+hex = tag_class(attrs = {
+    "name": attr.string(mandatory = True),
+    "version": attr.string(mandatory = True),
+    "sha256": attr.string(),
+    "build_file_content": attr.string(),
+    "patch_cmds": attr.string_list(),
+})
+
+git = tag_class(attrs = {
+    "name": attr.string(),
+    "remote": attr.string(),
+    "repository": attr.string(),
+    "branch": attr.string(),
+    "tag": attr.string(),
+    "commit": attr.string(),
+    "build_file_content": attr.string(),
+    "patch_cmds": attr.string_list(),
+})
+
+erlang_package = module_extension(
+    implementation = _erlang_package,
+    tag_classes = {
+        "hex": hex,
+        "hex_tree": hex_tree,
+        "git": git,
+    },
+)
+
+PATCH_AUTO_BUILD_BAZEL = """set -euo pipefail
+
+echo "Generating BUILD.bazel for {name}..."
+
+# if we have name, version and deps, we can just write
+# the file. this is the hex_tree case, and maybe others
+if [ -n "{version}" ]; then
+    if [ -n "{deps}" ]; then
+        cat << EOF > BUILD.bazel
+load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+
+erlang_app(
+    app_name = "{name}",
+    app_version = "{version}",
+    erlc_opts = [
+        "+deterministic",
+        "+debug_info",
+    ],
+    deps = {deps},
+)
+EOF
+    fi
+fi
+
+# if there is a Makefile and erlang.mk, use make to infer
+# the version and deps, error on name mismatch, and error
+# if the deps mismatch
+if [ ! -f BUILD.bazel ]; then
+    if [ -f Makefile ]; then
+        if [ -f erlang.mk ]; then
+            echo "\tAttempting auto-configure from erlang.mk files..."
+
+            cat << 'MK' > bazel-autobuild.mk
+define BUILD_FILE_CONTENT
+load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+
+erlang_app(
+    app_name = "$(PROJECT)",
+    app_description = \"""$(PROJECT_DESCRIPTION)\""",
+    app_version = "$(PROJECT_VERSION)",
+    app_env = \"""$(PROJECT_ENV)\""",
+    extra_apps = [
+$(foreach dep,$(LOCAL_DEPS),        "$(dep)",\n)    ],
+    erlc_opts = [
+        "+deterministic",
+        "+debug_info",
+    ],
+    build_deps = [
+$(foreach dep,$(BUILD_DEPS),        "@$(dep)//:erlang_app",\n)    ],
+    deps = [
+$(foreach dep,$(DEPS),        "@$(dep)//:erlang_app",\n)    ],
+)
+endef
+
+export BUILD_FILE_CONTENT
+
+BUILD.bazel:
+	echo "$$BUILD_FILE_CONTENT" >> $@
+MK
+            cat bazel-autobuild.mk
+            make -f Makefile -f bazel-autobuild.mk BUILD.bazel
+        fi
+    fi
+fi
+
+# fallback to BUILD file with just the name and version
+if [ ! -f BUILD.bazel ]; then
+    if [ -n "{version}" ]; then
+        cat << EOF > BUILD.bazel
+load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+
+erlang_app(
+    app_name = "{name}",
+    app_version = "{version}",
+    erlc_opts = [
+        "+deterministic",
+        "+debug_info",
+    ],
+)
+EOF
+    fi
+fi
+
+# fallback to BUILD file with just the name
+if [ ! -f BUILD.bazel ]; then
+    cat << EOF > BUILD.bazel
+load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+
+erlang_app(
+    app_name = "{name}",
+    erlc_opts = [
+        "+deterministic",
+        "+debug_info",
+    ],
+)
+EOF
+fi
+"""
+
+PATCH_AUTO_BUILD_BAZEL_WINDOWS = """REM bzlmod+windows dependency autobuild not yet supported
+REM you may use 'build_file_content' instead
+EXIT /B 1
+"""

--- a/bzlmod/hex_pm.bzl
+++ b/bzlmod/hex_pm.bzl
@@ -1,0 +1,87 @@
+def hex_package_info(ctx, name):
+    curl = ctx.which("curl")
+    endpoint = "https://hex.pm/api/packages/{}".format(name)
+    response = ctx.execute(
+        [curl, "--silent", endpoint],
+        timeout = 30,
+    )
+    if response.return_code != 0:
+        fail("hex.pm api returned {} for {}".format(response.return_code, endpoint))
+    return json.decode(response.stdout)
+
+def hex_release_info(ctx, name, version):
+    curl = ctx.which("curl")
+    endpoint = "https://hex.pm/api/packages/{}/releases/{}".format(name, version)
+    response = ctx.execute(
+        [curl, "--silent", endpoint],
+        timeout = 30,
+    )
+    if response.return_code != 0:
+        fail("hex.pm api returned {} for {}".format(response.return_code, endpoint))
+    return json.decode(response.stdout)
+
+Version = provider(fields = ["major", "minor", "patch"])
+
+def _version(version):
+    [major, minor, patch] = version.split(".", 2)
+    if not patch.isdigit():
+        return None
+    return Version(
+        major = int(major),
+        minor = int(minor),
+        patch = int(patch),
+    )
+
+def _gte(a, b):
+    if a.major > b.major:
+        return True
+    elif a.major == b.major:
+        if a.minor > b.minor:
+            return True
+        elif a.minor == b.minor:
+            return a.patch >= b.patch
+        else:
+            return False
+    else:
+        return False
+
+def _lt(a, b):
+    if a.major < b.major:
+        return True
+    elif a.major == b.major:
+        if a.minor < b.minor:
+            return True
+        elif a.minor == b.minor:
+            return a.patch < b.patch
+        else:
+            return False
+    else:
+        return False
+
+def _eq(a, b):
+    return a.major == b.major and a.minor == b.minor and a.patch == b.patch
+
+def newest(a, b):
+    if a.version == b.version:
+        return a
+    if _lt(_version(a.version), _version(b.version)):
+        return b
+    else:
+        return a
+
+def satisfies(version, requirement):
+    v = _version(version)
+    if v == None:
+        # print("Ignoring version", version)
+        return False
+    if requirement.startswith("~>"):
+        min = _version(requirement.removeprefix("~>").lstrip())
+        if min == None:
+            print("Ignoring requirement", requirement)
+            return False
+        max = Version(major = min.major, minor = min.minor + 1, patch = 0)
+        return _gte(v, min) and _lt(v, max)
+    elif _version(requirement) != None:
+        return _eq(v, _version(requirement))
+    else:
+        fail(requirement)

--- a/compile_first/BUILD.bazel
+++ b/compile_first/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//private:erlc.bzl", "erlc_private")
+load("//:erl_eval.bzl", "erl_eval")
+
+erlc_private(
+    name = "beam",
+    srcs = [
+        "src/compile_first.erl",
+    ],
+)
+
+erl_eval(
+    name = "escript",
+    srcs = [
+        ":beam",
+    ],
+    outs = [
+        "escript/compile_first",
+    ],
+    expression = """
+io:format("Assembiling compile_first escript...~n", []),
+Beam = os:getenv("SRCS"),
+Dest = os:getenv("OUTS"),
+ok = escript:create(Dest,
+                    [shebang, comment,
+                     {beam, Beam}]),
+io:format("done.~n", []),
+halt().
+""",
+    visibility = ["//visibility:public"],
+)

--- a/compile_first/src/compile_first.erl
+++ b/compile_first/src/compile_first.erl
@@ -1,0 +1,64 @@
+-module(compile_first).
+
+-mode(compile).
+
+-export([main/1]).
+
+-spec main([string()]) -> no_return().
+main(ErlFiles) ->
+    %% This can be a simplified analysis, as deps
+    %% are already compiled. We just need to cover
+    %% things like behaviors within the set of
+    %% ErlFiles
+
+    E = ets:new(makedep, [bag]),
+
+    [begin
+         case file:open(F, [read]) of
+             {ok, Fd} ->
+                 walk_forms(E, Fd, 0)
+         end
+     end || F <- ErlFiles],
+
+    %% any item in the table that is also one of the
+    %% ErlFiles should be compiled first
+    CompileFirst = lists:filter(fun (F) ->
+                                        Mod = list_to_atom(filename:basename(F, ".erl")),
+                                        ets:member(E, Mod)
+                                end, ErlFiles),
+
+    io:format("~s", [string:join(CompileFirst, " ")]),
+
+    halt().
+
+walk_forms(E, Fd, StartLocation) ->
+    case io:parse_erl_form(Fd, undefined, StartLocation) of
+        {ok, AbsData, EndLocation} ->
+            case AbsData of
+                {attribute, _, Key, Value} ->
+                    record_attr(E, Key, Value),
+                    walk_forms(E, Fd, EndLocation);
+                _ ->
+                    walk_forms(E, Fd, EndLocation)
+            end;
+        {eof, _} ->
+            file:close(Fd);
+        {error, _} ->
+            file:close(Fd);
+        {error, _, ErrorLocation} ->
+            walk_forms(E, Fd, ErrorLocation)
+    end.
+
+record_attr(E, behavior, Dep) ->
+    ets:insert(E, {Dep});
+record_attr(E, behaviour, Dep) ->
+    ets:insert(E, {Dep});
+record_attr(E, compile, {parse_transform, Dep}) ->
+    ets:insert(E, {Dep});
+record_attr(E, compile, Opts) when is_list(Opts) ->
+    case proplists:get_value(parse_transform, Opts) of
+        undefined -> ok;
+        Dep -> ets:insert(E, {Dep})
+    end;
+record_attr(_, _, _) ->
+    ok.

--- a/ct.bzl
+++ b/ct.bzl
@@ -1,9 +1,12 @@
 load(
     "//private:ct.bzl",
     "ct_test",
-    _additional_file_dest_relative_path = "additional_file_dest_relative_path",
     _code_paths = "code_paths",
     _sanitize_sname = "sanitize_sname",
+)
+load(
+    "//private:util.bzl",
+    _additional_file_dest_relative_path = "additional_file_dest_relative_path",
 )
 load(":erlc.bzl", "erlc")
 load(

--- a/erlang_app.bzl
+++ b/erlang_app.bzl
@@ -43,7 +43,8 @@ def erlang_app(
         extra_license_files = [],
         build_deps = [],
         deps = [],
-        runtime_deps = []):
+        runtime_deps = [],
+        stamp = -1):
     all_beam = []
 
     if len(first_srcs) > 0:
@@ -83,6 +84,7 @@ def erlang_app(
             app_src = native.glob(["src/{}.app.src".format(app_name)]),
             modules = all_beam,
             deps = deps + runtime_deps,
+            stamp = stamp,
         )
         app = ":app_file"
     else:

--- a/erlang_app.bzl
+++ b/erlang_app.bzl
@@ -151,7 +151,7 @@ def test_erlang_app(
     erlang_app_info(
         name = "test_erlang_app",
         app_name = app_name,
-        hdrs = native.glob(["include/**/*.hrl"]),
+        hdrs = native.glob(["include/**/*.hrl", "src/**/*.hrl"]),
         app = app,
         beam = all_test_beam,
         priv = native.glob(["priv/**/*"]) + extra_priv,

--- a/erlc.bzl
+++ b/erlc.bzl
@@ -1,4 +1,7 @@
 load("//private:erlc.bzl", "erlc_private")
 
 def erlc(**kwargs):
-    erlc_private(**kwargs)
+    erlc_private(
+        compile_first = Label("//compile_first:escript"),
+        **kwargs
+    )

--- a/github.bzl
+++ b/github.bzl
@@ -19,6 +19,7 @@ def github_erlang_app(
             first_srcs = first_srcs,
             deps = deps,
             runtime_deps = runtime_deps,
+            stamp = 0,
         ))
 
     repo = name if repo == None else repo

--- a/hex_archive.bzl
+++ b/hex_archive.bzl
@@ -64,7 +64,11 @@ def _impl(ctx):
     if ctx.attr.build_file and ctx.attr.build_file_content:
         fail("Only one of build_file and build_file_content can be provided.")
 
-    all_urls = ["https://repo.hex.pm/tarballs/{}-{}.tar".format(ctx.attr.name, ctx.attr.version)]
+    # we have package_name, because with bzlmod, the name is rewritten
+    # prior to download with a namespace
+    name = ctx.attr.package_name or ctx.attr.name
+
+    all_urls = ["https://repo.hex.pm/tarballs/{}-{}.tar".format(name, ctx.attr.version)]
 
     auth = _get_auth(ctx, all_urls)
 
@@ -83,6 +87,7 @@ def _impl(ctx):
     return update_attrs(ctx.attr, _hex_archive_attrs.keys(), {"sha256": download_info.sha256})
 
 _hex_archive_attrs = {
+    "package_name": attr.string(),
     "version": attr.string(mandatory = True),
     "sha256": attr.string(
         doc = """The expected SHA-256 of the file downloaded.

--- a/hex_pm.bzl
+++ b/hex_pm.bzl
@@ -33,5 +33,6 @@ erlang_app(
     first_srcs = {first_srcs},
     deps = {deps},
     runtime_deps = {runtime_deps},
+    stamp = 0,
 )
 """

--- a/private/BUILD.bazel
+++ b/private/BUILD.bazel
@@ -1,4 +1,4 @@
-exports_files([
-    "app_file.template",
-    "app_with_mod_file.template",
-])
+config_setting(
+    name = "private_stamp_detect",
+    values = {"stamp": "1"},
+)

--- a/private/app_file.template
+++ b/private/app_file.template
@@ -1,8 +1,0 @@
-{application, '$(PROJECT)', [
-	{description, "$(PROJECT_DESCRIPTION)"},
-	{vsn, "$(PROJECT_VERSION)"},$(PROJECT_ID_TERM)
-	{modules, $(MODULES_LIST)},
-	{registered, []},
-	{applications, $(APPLICATIONS_LIST)},
-	{env, $(PROJECT_ENV)}$(PROJECT_APP_EXTRA_KEYS)
-]}.

--- a/private/app_with_mod_file.template
+++ b/private/app_with_mod_file.template
@@ -1,9 +1,0 @@
-{application, '$(PROJECT)', [
-	{description, "$(PROJECT_DESCRIPTION)"},
-	{vsn, "$(PROJECT_VERSION)"},$(PROJECT_ID_TERM)
-	{modules, $(MODULES_LIST)},
-	{registered, $(REGISTERED_LIST)},
-	{applications, $(APPLICATIONS_LIST)},
-	{mod, {$(PROJECT_MOD), []}},
-	{env, $(PROJECT_ENV)}$(PROJECT_APP_EXTRA_KEYS)
-]}.

--- a/private/ct.bzl
+++ b/private/ct.bzl
@@ -1,5 +1,5 @@
 load("//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
-load("//:erlang_app_info.bzl", "ErlangAppInfo", "flat_deps")
+load("//:erlang_app_info.bzl", "ErlangAppInfo")
 load(
     "//:util.bzl",
     "BEGINS_WITH_FUN",
@@ -7,9 +7,7 @@ load(
     "path_join",
     "windows_path",
 )
-load(":erlc.bzl", "beam_file")
-
-ERL_LIBS_DIR = "deps"
+load(":util.bzl", "erl_libs_contents")
 
 def sanitize_sname(s):
     return s.replace("@", "-").replace(".", "_")
@@ -34,52 +32,6 @@ def code_paths(dep):
         for d in _unique_short_dirnames(dep[ErlangAppInfo].beam)
     ]
 
-def additional_file_dest_relative_path(dep_label, f):
-    if dep_label.workspace_root != "":
-        workspace_root = dep_label.workspace_root.replace("external/", "../")
-        rel_base = path_join(workspace_root, dep_label.package)
-    else:
-        rel_base = dep_label.package
-    if rel_base != "":
-        return f.short_path.replace(rel_base + "/", "")
-    else:
-        return f.short_path
-
-def erl_libs_contents(ctx, headers = False, dir = ERL_LIBS_DIR):
-    erlang_version = ctx.attr._erlang_version[ErlangVersionProvider].version
-
-    erl_libs_files = []
-    for dep in flat_deps(ctx.attr.deps):
-        lib_info = dep[ErlangAppInfo]
-        dep_path = path_join(dir, lib_info.app_name)
-        if lib_info.erlang_version != erlang_version:
-            fail("Mismatched erlang versions", erlang_version, lib_info.erlang_version)
-        if headers:
-            for hdr in lib_info.include:
-                dest = ctx.actions.declare_file(path_join(dep_path, "include", hdr.basename))
-                ctx.actions.symlink(output = dest, target_file = hdr)
-                erl_libs_files.append(dest)
-        for src in lib_info.beam:
-            if src.is_directory:
-                if len(lib_info.beam) != 1:
-                    fail("ErlangAppInfo.beam must be a collection of files, or a single ebin dir")
-                dest = ctx.actions.declare_directory(path_join(dep_path, "ebin"))
-                ctx.actions.run_shell(
-                    inputs = [src],
-                    outputs = [dest],
-                    command = "cp -R {} {}".format(src.path, dest.dirname),
-                )
-            else:
-                dest = ctx.actions.declare_file(path_join(dep_path, "ebin", src.basename))
-                ctx.actions.symlink(output = dest, target_file = src)
-            erl_libs_files.append(dest)
-        for src in lib_info.priv:
-            rp = additional_file_dest_relative_path(dep.label, src)
-            dest = ctx.actions.declare_file(path_join(dep_path, rp))
-            ctx.actions.symlink(output = dest, target_file = src)
-            erl_libs_files.append(dest)
-    return erl_libs_files
-
 def sname(ctx):
     return sanitize_sname("ct-{}-{}".format(
         ctx.label.package.rpartition("/")[-1],
@@ -89,7 +41,9 @@ def sname(ctx):
 def _impl(ctx):
     erlang_version = ctx.attr._erlang_version[ErlangVersionProvider].version
 
-    erl_libs_files = erl_libs_contents(ctx)
+    erl_libs_dir = ctx.label.name + "_deps"
+
+    erl_libs_files = erl_libs_contents(ctx, dir = erl_libs_dir)
 
     package = ctx.label.package
 
@@ -102,7 +56,7 @@ def _impl(ctx):
         if len(ctx.attr.cases) > 0:
             filter_tests_args = filter_tests_args + " -case " + " ".join(ctx.attr.cases)
 
-    erl_libs_path = path_join(package, ERL_LIBS_DIR)
+    erl_libs_path = path_join(package, erl_libs_dir)
 
     ct_hooks_args = ""
     if len(ctx.attr.ct_hooks) > 0:

--- a/private/ct_sharded.bzl
+++ b/private/ct_sharded.bzl
@@ -1,15 +1,14 @@
 load("//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
-load("//:erlang_app.bzl", "DEFAULT_TEST_ERLC_OPTS")
-load("//:erlang_app_info.bzl", "ErlangAppInfo", "flat_deps")
-load("//:erlc.bzl", "erlc")
+load("//:erlang_app_info.bzl", "ErlangAppInfo")
 load(
     ":ct.bzl",
-    "ERL_LIBS_DIR",
-    "erl_libs_contents",
     "short_dirname",
     "sname",
 )
-load(":erlc.bzl", "beam_file")
+load(
+    ":util.bzl",
+    "erl_libs_contents",
+)
 load(
     "//:util.bzl",
     "BEGINS_WITH_FUN",
@@ -21,11 +20,13 @@ load(
 def _impl(ctx):
     erlang_version = ctx.attr._erlang_version[ErlangVersionProvider].version
 
-    erl_libs_files = erl_libs_contents(ctx)
+    erl_libs_dir = ctx.label.name + "_deps"
+
+    erl_libs_files = erl_libs_contents(ctx, dir = erl_libs_dir)
 
     package = ctx.label.package
 
-    erl_libs_path = path_join(package, ERL_LIBS_DIR)
+    erl_libs_path = path_join(package, erl_libs_dir)
 
     ct_hooks_args = ""
     if len(ctx.attr.ct_hooks) > 0:

--- a/private/erlc.bzl
+++ b/private/erlc.bzl
@@ -80,7 +80,7 @@ def _impl(ctx):
         fi
 
         # use the compile_first escript to determine the first pass, if present
-        if [ -f {compile_first} ]; then
+        if [ -n "{compile_first}" ]; then
             FIRST=$("{erlang_home}"/bin/escript {compile_first} $@)
         else
             FIRST=

--- a/private/erlc.bzl
+++ b/private/erlc.bzl
@@ -1,11 +1,12 @@
 load("//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
-load("//:erlang_app_info.bzl", "ErlangAppInfo", "flat_deps")
+load("//:erlang_app_info.bzl", "ErlangAppInfo")
 load(
     "//:util.bzl",
     "BEGINS_WITH_FUN",
     "QUERY_ERL_VERSION",
     "path_join",
 )
+load(":util.bzl", "erl_libs_contents")
 
 def beam_file(ctx, src, dir):
     name = src.basename.replace(".erl", ".beam")
@@ -25,33 +26,41 @@ def _dirname(path):
 def _impl(ctx):
     erlang_version = ctx.attr._erlang_version[ErlangVersionProvider].version
 
+    erl_libs_dir = ctx.label.name + "_deps"
+
+    erl_libs_files = erl_libs_contents(
+        ctx,
+        transitive = False,
+        headers = True,
+        dir = erl_libs_dir,
+    )
+
+    # it would be nice to properly compute the path, but ctx.bin_dir.path
+    # does not appear to be the whole prefix
+    if len(erl_libs_files) > 0:
+        (output_dir, _, path) = erl_libs_files[0].path.partition(erl_libs_dir)
+        if output_dir == "":
+            fail("Could not compute the ERL_LIBS relative path from {}".format(
+                erl_libs_files[0].path,
+            ))
+        erl_libs_path = path_join(output_dir.rstrip("/"), erl_libs_dir)
+    else:
+        erl_libs_path = ""
+
     beam_files = [beam_file(ctx, src, ctx.attr.dest) for src in ctx.files.srcs]
 
     dest_dir = beam_files[0].dirname
 
-    erl_args = ctx.actions.args()
-    erl_args.add("-v")
-
+    include_args = []
     for dir in unique_dirnames(ctx.files.hdrs):
-        erl_args.add("-I", dir)
+        include_args.extend(["-I", dir])
 
-    for dep in ctx.attr.deps:
-        lib_info = dep[ErlangAppInfo]
-        if lib_info.erlang_version != erlang_version:
-            fail("Mismatched erlang versions", erlang_version, lib_info.erlang_version)
-        for dir in unique_dirnames(lib_info.include):
-            erl_args.add("-I", _dirname(_dirname(dir)))
-        for dir in unique_dirnames(lib_info.beam):
-            erl_args.add("-pa", dir)
-
+    pa_args = []
     for dir in unique_dirnames(ctx.files.beam):
-        erl_args.add("-pa", dir)
+        pa_args.extend(["-pa", dir])
 
-    erl_args.add("-o", dest_dir)
-
-    erl_args.add_all(ctx.attr.erlc_opts)
-
-    erl_args.add_all(ctx.files.srcs)
+    srcs = ctx.actions.args()
+    srcs.add_all(ctx.files.srcs)
 
     script = """
         set -euo pipefail
@@ -66,29 +75,56 @@ def _impl(ctx):
             exit 1
         fi
 
-        "{erlang_home}"/bin/erlc $@
+        if [ -n "{erl_libs_path}" ]; then
+            export ERL_LIBS={erl_libs_path}
+        fi
+
+        # use the compile_first escript to determine the first pass, if present
+        if [ -f {compile_first} ]; then
+            FIRST=$("{erlang_home}"/bin/escript {compile_first} $@)
+        else
+            FIRST=
+        fi
+
+        if [ -n "$FIRST" ]; then
+            "{erlang_home}"/bin/erlc \\
+                -v {include_args} {pa_args} -o {out_dir} {erlc_opts} \\
+                $FIRST
+            "{erlang_home}"/bin/erlc \\
+                -v {include_args} {pa_args} -pa {out_dir} -o {out_dir} {erlc_opts} \\
+                $@
+        else
+            "{erlang_home}"/bin/erlc \\
+                -v {include_args} {pa_args} -o {out_dir} {erlc_opts} \\
+                $@
+        fi
     """.format(
         dest_dir = dest_dir,
         begins_with_fun = BEGINS_WITH_FUN,
         query_erlang_version = QUERY_ERL_VERSION,
         erlang_version = erlang_version,
         erlang_home = ctx.attr._erlang_home[ErlangHomeProvider].path,
+        erl_libs_path = erl_libs_path,
+        compile_first = ctx.file.compile_first.path if ctx.file.compile_first != None else "",
+        include_args = " ".join(include_args),
+        pa_args = " ".join(pa_args),
+        out_dir = dest_dir,
+        erlc_opts = " ".join(ctx.attr.erlc_opts),
     )
 
     inputs = []
     inputs.extend(ctx.files.hdrs)
     inputs.extend(ctx.files.srcs)
-    for dep in ctx.attr.deps:
-        lib_info = dep[ErlangAppInfo]
-        inputs.extend(lib_info.include)
-        inputs.extend(lib_info.beam)
     inputs.extend(ctx.files.beam)
+    inputs.extend(erl_libs_files)
+    if ctx.file.compile_first != None:
+        inputs.append(ctx.file.compile_first)
 
     ctx.actions.run_shell(
         inputs = inputs,
         outputs = beam_files,
         command = script,
-        arguments = [erl_args],
+        arguments = [srcs],
         mnemonic = "ERLC",
     )
 
@@ -101,6 +137,9 @@ erlc_private = rule(
     attrs = {
         "_erlang_home": attr.label(default = Label("//:erlang_home")),
         "_erlang_version": attr.label(default = Label("//:erlang_version")),
+        "compile_first": attr.label(
+            allow_single_file = True,
+        ),
         "hdrs": attr.label_list(allow_files = [".hrl"]),
         "srcs": attr.label_list(
             mandatory = True,

--- a/private/eunit.bzl
+++ b/private/eunit.bzl
@@ -9,11 +9,7 @@ load(
     "path_join",
     "windows_path",
 )
-load(
-    ":ct.bzl",
-    "ERL_LIBS_DIR",
-    "erl_libs_contents",
-)
+load(":util.bzl", "erl_libs_contents")
 
 def _to_atom_list(l):
     return "[" + ",".join(["'{}'".format(i) for i in l]) + "]"
@@ -21,11 +17,13 @@ def _to_atom_list(l):
 def _impl(ctx):
     erlang_version = ctx.attr._erlang_version[ErlangVersionProvider].version
 
-    erl_libs_files = erl_libs_contents(ctx)
+    erl_libs_dir = ctx.label.name + "_deps"
+
+    erl_libs_files = erl_libs_contents(ctx, dir = erl_libs_dir)
 
     package = ctx.label.package
 
-    erl_libs_path = path_join(package, ERL_LIBS_DIR)
+    erl_libs_path = path_join(package, erl_libs_dir)
 
     if not ctx.attr.is_windows:
         test_env_commands = []

--- a/private/shell.bzl
+++ b/private/shell.bzl
@@ -8,8 +8,7 @@ load(
     "windows_path",
 )
 load(
-    ":ct.bzl",
-    "ERL_LIBS_DIR",
+    ":util.bzl",
     "erl_libs_contents",
 )
 

--- a/private/util.bzl
+++ b/private/util.bzl
@@ -1,0 +1,60 @@
+load("//:erlang_home.bzl", "ErlangVersionProvider")
+load("//:erlang_app_info.bzl", "ErlangAppInfo", "flat_deps")
+load(
+    "//:util.bzl",
+    "path_join",
+)
+
+_DEFAULT_ERL_LIBS_DIR = "deps"
+
+def additional_file_dest_relative_path(dep_label, f):
+    if dep_label.workspace_root != "":
+        workspace_root = dep_label.workspace_root.replace("external/", "../")
+        rel_base = path_join(workspace_root, dep_label.package)
+    else:
+        rel_base = dep_label.package
+    if rel_base != "":
+        return f.short_path.replace(rel_base + "/", "")
+    else:
+        return f.short_path
+
+def erl_libs_contents(ctx, transitive = True, headers = False, dir = _DEFAULT_ERL_LIBS_DIR):
+    erlang_version = ctx.attr._erlang_version[ErlangVersionProvider].version
+
+    if transitive:
+        deps = flat_deps(ctx.attr.deps)
+    else:
+        deps = ctx.attr.deps
+
+    erl_libs_files = []
+    for dep in deps:
+        lib_info = dep[ErlangAppInfo]
+        dep_path = path_join(dir, lib_info.app_name)
+        if lib_info.erlang_version != erlang_version:
+            fail("Mismatched erlang versions", erlang_version, lib_info.erlang_version)
+        if headers:
+            for hdr in lib_info.include:
+                rp = additional_file_dest_relative_path(dep.label, hdr)
+                dest = ctx.actions.declare_file(path_join(dep_path, rp))
+                ctx.actions.symlink(output = dest, target_file = hdr)
+                erl_libs_files.append(dest)
+        for src in lib_info.beam:
+            if src.is_directory:
+                if len(lib_info.beam) != 1:
+                    fail("ErlangAppInfo.beam must be a collection of files, or a single ebin dir")
+                dest = ctx.actions.declare_directory(path_join(dep_path, "ebin"))
+                ctx.actions.run_shell(
+                    inputs = [src],
+                    outputs = [dest],
+                    command = "cp -R {} {}".format(src.path, dest.dirname),
+                )
+            else:
+                dest = ctx.actions.declare_file(path_join(dep_path, "ebin", src.basename))
+                ctx.actions.symlink(output = dest, target_file = src)
+            erl_libs_files.append(dest)
+        for src in lib_info.priv:
+            rp = additional_file_dest_relative_path(dep.label, src)
+            dest = ctx.actions.declare_file(path_join(dep_path, rp))
+            ctx.actions.symlink(output = dest, target_file = src)
+            erl_libs_files.append(dest)
+    return erl_libs_files


### PR DESCRIPTION
- Add the `erlang_package` module extension which allows for similar but
substantially improved functionality from our `hex_pm_erlang_app` and
`github_erlang_app` workspace macros
    - `erlang_package.hex` behaves like `hex_pm_erlang_app`, but can better infer package properties
    - `erlang_package.hex_tree` with fetch the package and it's dependencies from hex.pm, performing a certain amount of dependency resolution
    - `erlang_package.git` behaves like `github_erlang_app`, but can better infer package properties and is not strictly limited to github
- Automatically compile behaviours and parse transforms first in the
`erlc` macro, so that first_srcs are usually no longer necessary in the
erlang_app macro
- Generate/Update `.app` files with erlang, rather than simple string substitutions, making things like updating of `{modules, ...}` work correctly regardless of whitespace. Additionally, this allows values on the `erlang_app` macro, like `app_description` to be injected overtop of whatever is in `src/*.app.src`, if the file is present. Previously in this case `app_description` would have been silently ignored.
- Allow stamping of `.app` files with a version

Additionally, erlc no longer assumes that dependencies sit in
directories named after their erlang app name (as is no longer the
case when using bzlmod). Additionally, the :test_erlang_app now
includes private headers.This way test sources, like _SUITE.erl files,
can include_lib them. This wasn't necessary given prior assumptions,
but seems a reasonable way to keep everything working.