### PR TITLE
WIP: fancy app_file_tool that uses json

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,12 +4,13 @@ module(
     compatibility_level = 2,
 )
 
-download_xrefr = use_extension(
+rules_erlang_dependencies = use_extension(
     "//bzlmod:extensions.bzl",
-    "download_xrefr",
+    "rules_erlang_dependencies",
 )
 
 use_repo(
-    download_xrefr,
+    rules_erlang_dependencies,
     "xrefr",
+    "jsx-source",
 )

--- a/app_file_tool/BUILD.bazel
+++ b/app_file_tool/BUILD.bazel
@@ -1,30 +1,38 @@
-load("//private:erlc.bzl", "erlc_private")
-load("//:erl_eval.bzl", "erl_eval")
+load("//:erlc.bzl", "erlc")
+load("//:erlang_app_info.bzl", "erlang_app_info")
+load("//private:escript.bzl", "escript_private")
 
-erlc_private(
-    name = "beam",
-    srcs = [
-        "src/app_file_tool.erl",
+APP_NAME = "app_file_tool"
+
+erlc(
+    name = "beam_files",
+    srcs = glob(["src/**/*.erl"]),
+    hdrs = glob([
+        "include/**/*.hrl",
+        "src/**/*.hrl",
+    ]),
+    dest = "ebin",
+    erlc_opts = [
+        "+deterministic",
+        "+debug_info",
     ],
 )
 
-erl_eval(
+erlang_app_info(
+    name = "erlang_app",
+    hdrs = glob(["include/**/*.hrl"]),
+    app = "ebin/app_file_tool.app",
+    app_name = APP_NAME,
+    beam = [":beam_files"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//app_file_tool/jsx:erlang_app",
+    ],
+)
+
+escript_private(
     name = "escript",
-    srcs = [
-        ":beam",
-    ],
-    outs = [
-        "escript/app_file_tool",
-    ],
-    expression = """
-io:format("Assembiling app_file_tool escript...~n", []),
-Beam = os:getenv("SRCS"),
-Dest = os:getenv("OUTS"),
-ok = escript:create(Dest,
-                    [shebang, comment,
-                     {beam, Beam}]),
-io:format("done.~n", []),
-halt().
-""",
+    out = "escript/app_file_tool",
+    app = ":erlang_app",
     visibility = ["//visibility:public"],
 )

--- a/app_file_tool/ebin/app_file_tool.app
+++ b/app_file_tool/ebin/app_file_tool.app
@@ -1,0 +1,13 @@
+{application, app_file_tool,
+[
+    {description, "a streaming, evented json parsing toolkit"},
+    {vsn, "0.1.0"},
+    {modules, [app_file_tool]},
+    {registered, []},
+    {applications, [
+        kernel,
+        stdlib,
+        jsx
+    ]},
+    {env, []}
+]}.

--- a/app_file_tool/jsx/BUILD.bazel
+++ b/app_file_tool/jsx/BUILD.bazel
@@ -1,0 +1,32 @@
+load("//:erlc.bzl", "erlc")
+load("//:erlang_app_info.bzl", "erlang_app_info")
+
+APP_NAME = "jsx"
+
+erlc(
+    name = "beam_files",
+    srcs = ["@jsx-source//:srcs"],
+    hdrs = ["@jsx-source//:hdrs"],
+    dest = "ebin",
+    erlc_opts = [
+        "+deterministic",
+        "+debug_info",
+    ],
+)
+
+genrule(
+    name = "app_file",
+    srcs = ["@jsx-source//:src/jsx.app.src"],
+    outs = ["ebin/jsx.app"],
+    cmd = "cp $< $@",
+)
+
+erlang_app_info(
+    name = "erlang_app",
+    hdrs = ["@jsx-source//:hdrs"],
+    app = ":app_file",
+    app_name = APP_NAME,
+    beam = [":beam_files"],
+    priv = ["@jsx-source//:priv"],
+    visibility = ["//visibility:public"],
+)

--- a/app_file_tool/src/app_file_tool.erl
+++ b/app_file_tool/src/app_file_tool.erl
@@ -4,21 +4,57 @@
 
 -export([main/1]).
 
+-define(SPECIAL_MERGE_KEY, app_file_tool_special_merge_key).
+
 -spec main([string()]) -> no_return().
-main([KeyString, AppSrc]) ->
-    Key = list_to_atom(KeyString),
-    {ok, Value} = io:read(""),
-    {ok, [AppInfo]} = file:consult(AppSrc),
-    {application, AppName, Props} = AppInfo,
-    NewProps = lists:keystore(Key, 1, Props, {Key, Value}),
-    io:format("~tp.~n", [{application, AppName, NewProps}]),
-    halt();
 main([AppSrc]) ->
-    {ok, Entries} = io:read(""),
+    ok = io:setopts([binary]),
+    Overrides = conform(decode_json_from(standard_io)),
     {ok, [AppInfo]} = file:consult(AppSrc),
     {application, AppName, Props} = AppInfo,
-    NewProps = Props ++ Entries,
+    NewProps = lists:foldl(fun (Override, Acc) ->
+        lists:keystore(element(1, Override), 1, Acc, Override)
+    end, Props, Overrides),
     io:format("~tp.~n", [{application, AppName, NewProps}]),
     halt();
 main(_) ->
     halt(1).
+
+conform(Overrides) ->
+    lists:reverse(maps:fold(fun
+        (?SPECIAL_MERGE_KEY, Value, Acc) ->
+            Terms = parse_terms(binary_to_list(Value)),
+            lists:reverse(Terms) ++ Acc;
+        (Key, Value, Acc) when is_binary(Value) ->
+           [{binary_to_atom(Key), binary_to_list(Value)} | Acc];
+        (Key, Value, Acc) when is_list(Value) ->
+            [{binary_to_atom(Key), conform_list(Value)} | Acc];
+         (Key, Value, Acc) ->
+            [{binary_to_atom(Key), Value} | Acc]
+    end, [], Overrides)).
+
+conform_list(Values) when is_list(Values) ->
+    lists:map(fun
+        (V) when is_binary(V) -> binary_to_list(V);
+        (V) -> V
+    end, Values).
+
+decode_json_from(IoDevice) ->
+    decode_rest(IoDevice, {incomplete, fun (Data) ->
+        jsx:decode(Data, [stream])
+    end}).
+
+decode_rest(IoDevice, {incomplete, Decoder}) ->
+    case file:read_line(IoDevice) of
+        {ok, Data} ->
+            decode_rest(IoDevice, Decoder(Data));
+        eof ->
+            Decoder(end_stream)
+    end;
+decode_rest(_, Value) ->
+    Value.
+
+parse_terms(String) ->
+    {ok, Tokens, _} = erl_scan:string("[" + String ++ "]."),
+    {ok, Terms} = erl_parse:parse_term(Tokens),
+    Terms.

--- a/bzlmod/extensions.bzl
+++ b/bzlmod/extensions.bzl
@@ -1,4 +1,7 @@
-load("//:rules_erlang.bzl", "rules_erlang_dependencies")
+load(
+    "//:rules_erlang.bzl",
+    _rules_erlang_dependencies = "rules_erlang_dependencies",
+)
 load("//:hex_archive.bzl", "hex_archive")
 load(
     ":hex_pm.bzl",
@@ -13,11 +16,11 @@ load(
     "new_git_repository",
 )
 
-def _download_xrefr(ctx):
-    rules_erlang_dependencies()
+def _rules_erlang_deps(ctx):
+    _rules_erlang_dependencies()
 
-download_xrefr = module_extension(
-    implementation = _download_xrefr,
+rules_erlang_dependencies = module_extension(
+    implementation = _rules_erlang_deps,
 )
 
 HexPackage = provider(fields = [

--- a/rules_erlang.bzl
+++ b/rules_erlang.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 def rules_erlang_dependencies():
     http_file(
@@ -6,4 +6,31 @@ def rules_erlang_dependencies():
         urls = ["https://github.com/inaka/xref_runner/releases/download/1.2.0/xrefr"],
         executable = True,
         sha256 = "b50df06b8112852722667b5a5afdb0a9f4549cd5da7a0c157cfd34f29eee3b5c",
+    )
+
+    http_archive(
+        name = "jsx-source",
+        urls = ["https://github.com/talentdeficit/jsx/archive/refs/tags/v3.1.0.zip"],
+        strip_prefix = "jsx-3.1.0",
+        build_file_content = """
+exports_files(["src/jsx.app.src"])
+
+filegroup(
+    name = "hdrs",
+    srcs = glob(["include/**/*.hrl", "src/**/*.hrl"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["src/**/*.erl"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "priv",
+    srcs = glob(["priv/**/*"]),
+    visibility = ["//visibility:public"],
+)
+""",
     )


### PR DESCRIPTION
Modify `app_file_tool` to receive overrides to .app files as json.

Bazel has built in classes for encoding & decoding json, so my thought was that we could pass information from Bazel more cleanly than the current approach.