### PR TITLE
Remove the `first_srcs` arg to fix the build of github and hex apps

### DIFF
--- a/github.bzl
+++ b/github.bzl
@@ -7,7 +7,6 @@ def github_erlang_app(
         version = "master",
         ref = "refs/heads/master",
         extra_apps = [],
-        first_srcs = [],
         deps = [],
         runtime_deps = [],
         **kwargs):
@@ -37,7 +36,6 @@ erlang_app(
     app_name = "{app_name}",
     app_version = "{version}",
     extra_apps = {extra_apps},
-    first_srcs = {first_srcs},
     deps = {deps},
     runtime_deps = {runtime_deps},
 )

--- a/hex_pm.bzl
+++ b/hex_pm.bzl
@@ -5,7 +5,6 @@ def hex_pm_erlang_app(
         name = None,
         version = None,
         erlc_opts = DEFAULT_ERLC_OPTS,
-        first_srcs = [],
         deps = [],
         runtime_deps = [],
         **kwargs):
@@ -16,7 +15,6 @@ def hex_pm_erlang_app(
             app_name = name,
             version = version,
             erlc_opts = erlc_opts,
-            first_srcs = first_srcs,
             deps = deps,
             runtime_deps = runtime_deps,
         ),
@@ -29,7 +27,6 @@ erlang_app(
     app_name = "{app_name}",
     app_version = "{version}",
     erlc_opts = {erlc_opts},
-    first_srcs = {first_srcs},
     deps = {deps},
     runtime_deps = {runtime_deps},
     stamp = 0,


### PR DESCRIPTION
As per title - the new version doesn't seem to use the `first_srcs` argument anywhere, and it was preventing the Github and Hex targets from building.