### PR TITLE
Fix usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ assert_suites([
 build --@rules_erlang//:erlang_home=/path/to/erlang
 build --@rules_erlang//:erlang_version=23.2
 
-build --platforms=@rules_erlang//:erlang_external_platform
-build --extra_execution_platforms=@rules_erlang//:erlang_external_platform
+build --platforms=@rules_erlang//platforms:erlang_external_platform
+build --extra_execution_platforms=@rules_erlang//platforms:erlang_external_platform
 ```
 
 ### Compile and run all tests


### PR DESCRIPTION
Without this change, trying to use the rules as they are in the README will result in the following error:
```
While resolving toolchains for target @gpb//:erlang_app: com.google.devtools.build.lib.packages.NoSuchTargetException: no such target '@rules_erlang//:erlang_external_platform': target 'erlang_external_platform' not declared in package ''
```

Adding the prefix fixes it. I think this is the only place where this is referenced, but let me know if I missed more places.