### PR TITLE
Copy rather than symlink erlang into place

### DIFF
--- a/private/app_file.bzl
+++ b/private/app_file.bzl
@@ -3,7 +3,7 @@ load("//:util.bzl", "path_join")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def _module_name(f):
@@ -48,7 +48,7 @@ def _impl(ctx):
 
     script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 if [ -n "{src}" ]; then
     cp {src} {out}
@@ -121,7 +121,7 @@ if [ -n '{extra_keys}' ]; then
 EOF
 fi
 """.format(
-        maybe_symlink_erlang = maybe_symlink_erlang(ctx),
+        maybe_install_erlang = maybe_install_erlang(ctx),
         erlang_home = erlang_home,
         app_file_tool = app_file_tool_path,
         info_file = ctx.info_file.path,

--- a/private/ct.bzl
+++ b/private/ct.bzl
@@ -8,7 +8,7 @@ load(
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def sanitize_sname(s):
@@ -66,7 +66,7 @@ def _impl(ctx):
         output = ctx.actions.declare_file(ctx.label.name)
         script = """set -eo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 if [ -n "{shard_suite}" ]; then
     if [ -n "${{TEST_SHARD_STATUS_FILE+x}}" ]; then
@@ -120,7 +120,7 @@ set -x
     {ct_hooks_args} \\
     -sname {sname}
 """.format(
-            maybe_symlink_erlang = maybe_symlink_erlang(ctx, short_path = True),
+            maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
             erlang_home = erlang_home,
             package = package,
             erl_libs_path = erl_libs_path,

--- a/private/dialyze.bzl
+++ b/private/dialyze.bzl
@@ -1,7 +1,7 @@
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 load("//:erlang_app_info.bzl", "ErlangAppInfo")
 load("//:util.bzl", "windows_path")
@@ -27,7 +27,7 @@ def _impl(ctx):
         output = ctx.actions.declare_file(ctx.label.name)
         script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 export HOME=${{TEST_TMPDIR}}
 
@@ -36,7 +36,7 @@ set -x
     {plt_args} \\
     -r {dirs} {opts}{check_warnings}
 """.format(
-            maybe_symlink_erlang = maybe_symlink_erlang(ctx, short_path = True),
+            maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
             erlang_home = erlang_home,
             apps_args = apps_args,
             plt_args = plt_args,

--- a/private/erl_eval.bzl
+++ b/private/erl_eval.bzl
@@ -1,7 +1,7 @@
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def _impl(ctx):
@@ -14,7 +14,7 @@ def _impl(ctx):
 
     script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 export SRCS="{srcs}"
 export OUTS="{outs}"
@@ -23,7 +23,7 @@ export OUTS="{outs}"
     -noshell \\
     -eval "$1"
 """.format(
-        maybe_symlink_erlang = maybe_symlink_erlang(ctx),
+        maybe_install_erlang = maybe_install_erlang(ctx),
         erlang_home = erlang_home,
         srcs = ctx.configuration.host_path_separator.join([src.path for src in ctx.files.srcs]),
         outs = ctx.configuration.host_path_separator.join([out.path for out in outs]),

--- a/private/erlang_bytecode.bzl
+++ b/private/erlang_bytecode.bzl
@@ -4,7 +4,7 @@ load(":util.bzl", "erl_libs_contents")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def beam_file(ctx, src, dir):
@@ -69,7 +69,7 @@ def _impl(ctx):
 
     script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 mkdir -p {dest_dir}
 
@@ -97,7 +97,7 @@ else
         $@
 fi
     """.format(
-        maybe_symlink_erlang = maybe_symlink_erlang(ctx),
+        maybe_install_erlang = maybe_install_erlang(ctx),
         erlang_home = erlang_home,
         dest_dir = dest_dir,
         erl_libs_path = erl_libs_path,

--- a/private/erlang_tool.bzl
+++ b/private/erlang_tool.bzl
@@ -1,7 +1,7 @@
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 DEFAULT_PATH = "bin/erl"
@@ -15,11 +15,11 @@ def _impl(ctx):
         output = out,
         content = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 exec "{erlang_home}"/{path} $@
 """.format(
-            maybe_symlink_erlang = maybe_symlink_erlang(ctx, short_path = True),
+            maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
             erlang_home = erlang_home,
             path = ctx.attr.path,
         ),

--- a/private/escript_archive.bzl
+++ b/private/escript_archive.bzl
@@ -1,7 +1,7 @@
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 load(
     "//:erlang_app_info.bzl",
@@ -67,7 +67,7 @@ def _impl(ctx):
 
     script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 "{erlang_home}"/bin/erl \\
     -noshell \\
@@ -83,7 +83,7 @@ io:format("done.~n", []),
 halt().
 '
 """.format(
-        maybe_symlink_erlang = maybe_symlink_erlang(ctx),
+        maybe_install_erlang = maybe_install_erlang(ctx),
         erlang_home = erlang_home,
         name = name,
         headers = "".join(["{}, ".format(h) for h in ctx.attr.headers]),

--- a/private/escript_flat.bzl
+++ b/private/escript_flat.bzl
@@ -1,7 +1,7 @@
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def _impl(ctx):
@@ -38,11 +38,11 @@ halt().
         outputs = [out],
         command = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 "{erlang_home}"/bin/erl -noshell -eval "$@"
 """.format(
-            maybe_symlink_erlang = maybe_symlink_erlang(ctx),
+            maybe_install_erlang = maybe_install_erlang(ctx),
             erlang_home = erlang_home,
         ),
         arguments = [args],

--- a/private/eunit.bzl
+++ b/private/eunit.bzl
@@ -8,7 +8,7 @@ load(":util.bzl", "erl_libs_contents")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def _to_atom_list(l):
@@ -33,7 +33,7 @@ def _impl(ctx):
         output = ctx.actions.declare_file(ctx.label.name)
         script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 export HOME=${{TEST_TMPDIR}}
 export ERL_LIBS=$TEST_SRCDIR/$TEST_WORKSPACE/{erl_libs_path}
@@ -49,7 +49,7 @@ set -x
     -pa test \\
     -eval "case eunit:test({eunit_mods_term},[]) of ok -> ok; error -> halt(2) end, halt()"
 """.format(
-            maybe_symlink_erlang = maybe_symlink_erlang(ctx, short_path = True),
+            maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
             erlang_home = erlang_home,
             erl_libs_path = erl_libs_path,
             package = package,

--- a/private/generlang.bzl
+++ b/private/generlang.bzl
@@ -1,7 +1,7 @@
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def _impl(ctx):
@@ -21,13 +21,13 @@ def _impl(ctx):
 
     script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 export PATH="{erlang_home}"/bin:${{PATH}}
 
 {cmd}
 """.format(
-        maybe_symlink_erlang = maybe_symlink_erlang(ctx),
+        maybe_install_erlang = maybe_install_erlang(ctx),
         erlang_home = erlang_home,
         cmd = cmd,
     )

--- a/private/plt.bzl
+++ b/private/plt.bzl
@@ -3,7 +3,7 @@ load(":erlang_bytecode.bzl", "unique_dirnames")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 DEFAULT_PLT_APPS = ["erts", "kernel", "stdlib"]
@@ -36,7 +36,7 @@ def _impl(ctx):
 
     script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 # without HOME being set, dialyzer will error regarding a default plt
 export HOME={home}
@@ -54,7 +54,7 @@ if [ ! $R -eq 0 ]; then
 fi
 exit $R
 """.format(
-        maybe_symlink_erlang = maybe_symlink_erlang(ctx),
+        maybe_install_erlang = maybe_install_erlang(ctx),
         erlang_home = erlang_home,
         home = home_dir.path,
         apps_args = apps_args,

--- a/private/shell.bzl
+++ b/private/shell.bzl
@@ -8,7 +8,7 @@ load(":util.bzl", "erl_libs_contents")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def _impl(ctx):
@@ -26,14 +26,14 @@ def _impl(ctx):
         output = ctx.actions.declare_file(ctx.label.name)
         script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 export ERL_LIBS=$PWD/{erl_libs_path}
 
 set -x
 "{erlang_home}"/bin/erl {extra_erl_args} $@
 """.format(
-            maybe_symlink_erlang = maybe_symlink_erlang(ctx, short_path = True),
+            maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
             erlang_home = erlang_home,
             erl_libs_path = erl_libs_path,
             extra_erl_args = " ".join(ctx.attr.extra_erl_args),

--- a/private/xref.bzl
+++ b/private/xref.bzl
@@ -13,7 +13,7 @@ load(
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def _impl(ctx):
@@ -53,7 +53,7 @@ def _impl(ctx):
         output = ctx.actions.declare_file(ctx.label.name)
         script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 export HOME=${{TEST_TMPDIR}}
 
@@ -65,7 +65,7 @@ set -x
 "{erlang_home}"/bin/escript {xrefr} \\
     --config {config_path}
 """.format(
-            maybe_symlink_erlang = maybe_symlink_erlang(ctx, short_path = True),
+            maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
             erlang_home = erlang_home,
             xrefr = xrefr_path,
             config_path = config_file.short_path,

--- a/private/xref2.bzl
+++ b/private/xref2.bzl
@@ -17,7 +17,7 @@ load(
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def _replace_all(s, substitutions):
@@ -109,7 +109,7 @@ def _impl(ctx):
         output = ctx.actions.declare_file(ctx.label.name)
         script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 export HOME=${{TEST_TMPDIR}}
 export ERL_LIBS=$TEST_SRCDIR/$TEST_WORKSPACE/{erl_libs_path}
@@ -123,7 +123,7 @@ fi
     -eval "{xref_erl}" \\
     -pa ebin/
 """.format(
-            maybe_symlink_erlang = maybe_symlink_erlang(ctx, short_path = True),
+            maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
             erlang_home = erlang_home,
             erl_libs_path = erl_libs_path,
             package = ctx.label.package,
@@ -210,7 +210,7 @@ def _query_impl(ctx):
         output = ctx.actions.declare_file(ctx.label.name)
         script = """set -euo pipefail
 
-{maybe_symlink_erlang}
+{maybe_install_erlang}
 
 export ERL_LIBS=$PWD/{erl_libs_path}
 
@@ -225,7 +225,7 @@ export QUERY="$1"
     -eval "{xref_erl}" \\
     -pa ebin/
 """.format(
-            maybe_symlink_erlang = maybe_symlink_erlang(ctx, short_path = True),
+            maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
             erlang_home = erlang_home,
             erl_libs_path = erl_libs_path,
             package = ctx.label.package,

--- a/tools/erlang_headers.bzl
+++ b/tools/erlang_headers.bzl
@@ -2,14 +2,14 @@ load("//:util.bzl", "path_join")
 load(
     ":erlang_toolchain.bzl",
     "erlang_dirs",
-    "maybe_symlink_erlang",
+    "maybe_install_erlang",
 )
 
 def _erlang_headers_impl(ctx):
     commands = [
         "set -euo pipefail",
         "",
-        maybe_symlink_erlang(ctx),
+        maybe_install_erlang(ctx),
         "",
     ]
 

--- a/tools/erlang_toolchain.bzl
+++ b/tools/erlang_toolchain.bzl
@@ -36,14 +36,14 @@ def erlang_dirs(ctx):
         ])
     return (info.erlang_home, info.release_dir, runfiles)
 
-def maybe_symlink_erlang(ctx, short_path = False):
+def maybe_install_erlang(ctx, short_path = False):
     info = _build_info(ctx)
     release_dir = info.release_dir
     if release_dir == None:
         return ""
     else:
         return """mkdir -p $(dirname "{erlang_home}")
-ln -sf $PWD/{erlang_release_dir} "{erlang_home}"
+cp -r {erlang_release_dir} "{erlang_home}"
 ERTS_DIRNAME="$(basename "$(echo "{erlang_home}"/erts-*)")"
 ln -sf ../$ERTS_DIRNAME/bin/epmd "{erlang_home}"/bin/epmd
 """.format(


### PR DESCRIPTION
when using bazel built erlang, as the symlink approach causes issues with dialyzer on erlang 25