### PR TITLE
Allow data targets for the shell rule

### DIFF
--- a/private/shell.bzl
+++ b/private/shell.bzl
@@ -58,6 +58,7 @@ echo on
     )
 
     runfiles = ctx.runfiles(
+        files = ctx.files.data,
         transitive_files = depset(erl_libs_files),
     )
 
@@ -72,6 +73,7 @@ shell = rule(
         "is_windows": attr.bool(mandatory = True),
         "deps": attr.label_list(providers = [ErlangAppInfo]),
         "extra_erl_args": attr.string_list(),
+        "data": attr.label_list(allow_files = True),
     },
     toolchains = ["//tools:toolchain_type"],
     executable = True,


### PR DESCRIPTION
As per title - this allows passing in data targets for the `shell` rule to use - e.g. config files and such:
```bazel
filegroup(
    name = "config_files",
    srcs = glob([ "config-files/*.config"]),
)

shell(
    name = "my-shell",
    deps = [":erlang_app"],
    data = [":config_files"],
    extra_erl_args = [
        "-config", "config-files/my.config",
    ],
)
```