### PR TITLE
Allow overriding the compile_first argument in bytecode rule

### DIFF
--- a/erlang_bytecode.bzl
+++ b/erlang_bytecode.bzl
@@ -3,8 +3,10 @@ load(
     _erlang_bytecode = "erlang_bytecode",
 )
 
-def erlang_bytecode(**kwargs):
-    _erlang_bytecode(
+def erlang_bytecode(
         compile_first = Label("//tools/compile_first:compile_first"),
+        **kwargs):
+    _erlang_bytecode(
+        compile_first = compile_first,
         **kwargs
     )


### PR DESCRIPTION
This makes it possible to pass a custom script for the `compile_first` analysis, or to ignore it entirely.

If you're interested we can also upstream our `erlang_app_simple` rule that, using this hatch, shuts the source analysis phase and splits a package into a target per source file, allowing for fast rebuilds for local packages (i.e. when developing locally and a file is changed, then only its beam is rebuilt)