### PR TITLE
Allow ~ in the name of escripts

### DIFF
--- a/private/escript_archive.bzl
+++ b/private/escript_archive.bzl
@@ -71,7 +71,7 @@ def _impl(ctx):
 
 "{erlang_home}"/bin/erl \\
     -noshell \\
-    -eval 'io:format("Assembling {name} escript...~n", []),
+    -eval 'io:format("Assembling ~s escript...~n", ["{name}"]),
 ArchiveEntries = [begin
     {{ok, Bin}} = file:read_file(Path),
     {{Name, Bin}}

--- a/private/escript_flat.bzl
+++ b/private/escript_flat.bzl
@@ -15,8 +15,9 @@ def _impl(ctx):
         body = "{{beam,\"{}\"}}".format(ctx.file.beam.path)
 
     args = ctx.actions.args()
-    args.add("""io:format("Assembiling {out} escript...~n", []),
-ok = escript:create("{out}",
+    args.add("""EscriptPath = "{out}",
+io:format("Assembiling ~s escript...~n", [EscriptPath]),
+ok = escript:create(EscriptPath,
                     [shebang, comment,
                     {body}]),
 io:format("done.~n", []),


### PR DESCRIPTION
Previously the path was passed unescaped, which would cause failures with the latests bazel pre-releases and bzlmod