### PR TITLE
Update erlang headers default files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -141,6 +141,11 @@ jobs:
     #!     build:rbe --host_cpu=k8
     #!     build:rbe --cpu=k8
     #!     EOF
+    - name: BUILD
+      working-directory: test
+      run: |
+        bazelisk build @rules_erlang//tools:erlang_headers \
+          --config=rbe
     - name: TEST
       working-directory: test
       run: |

--- a/tools/erlang_headers.bzl
+++ b/tools/erlang_headers.bzl
@@ -14,7 +14,6 @@ DEFAULT_FILENAMES = [
     "erl_drv_nif.h",
     "erl_fixed_size_int_types.h",
     "erl_int_sizes_config.h",
-    "erl_memory_trace_parser.h",
     "erl_nif.h",
     "erl_nif_api_funcs.h",
 ]


### PR DESCRIPTION
`erl_memory_trace_parser.h` isn't present by default with erlang 25 (or may have been eliminated entirely

also updates `presubmit.yml` for compatibility with BCR