### PR TITLE
Add @rules_erlang//:debug_build config_setting

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,17 @@ load(
     "@bazel_skylib//rules:common_settings.bzl",
     "string_flag",
 )
+load(
+    "//tools:erlang.bzl",
+    "erlang_toolchain_external",
+)
+
+config_setting(
+    name = "debug_build",
+    values = {
+        "compilation_mode": "dbg",
+    },
+)
 
 string_flag(
     name = "erlang_home",
@@ -13,11 +24,6 @@ string_flag(
     name = "erlang_version",
     build_setting_default = "",
     visibility = ["//visibility:public"],
-)
-
-load(
-    "//tools:erlang.bzl",
-    "erlang_toolchain_external",
 )
 
 erlang_toolchain_external()


### PR DESCRIPTION
Can be used to select certain compilations when `-c dbg` is passed to bazel

For example: https://github.com/rabbitmq/rabbitmq-server/blob/576a886ae8f18691dfd40eeeb82ba1c8040c6cf3/rabbitmq.bzl#L156-L159