### PR TITLE
erlang_toolchain now provides TemplateVariableInfo

### DIFF
--- a/test/custom_vars/BUILD.bazel
+++ b/test/custom_vars/BUILD.bazel
@@ -1,0 +1,18 @@
+genrule(
+    name = "show_custom_var",
+    srcs = [],
+    outs = ["custom_var"],
+    cmd = 'echo "OTP_VERSION: $(OTP_VERSION)" > $@',
+    # genrule toolchains are not resolved in the same manner of
+    # custom rules, so we simulate it with select in this case
+    toolchains = select({
+        "@rules_erlang//platforms:erlang_25": ["//:erlang_25"],
+        "@rules_erlang//platforms:erlang_external": ["//:erlang_external"],
+    }),
+)
+
+sh_test(
+    name = "custom_var_test",
+    srcs = ["custom_var_test.sh"],
+    data = [":show_custom_var"],
+)

--- a/test/custom_vars/custom_var_test.sh
+++ b/test/custom_vars/custom_var_test.sh
@@ -1,0 +1,5 @@
+set -ex
+
+cat custom_vars/custom_var
+
+grep 'OTP_VERSION: 2[3-5]\.' custom_vars/custom_var

--- a/tools/erlang.bzl
+++ b/tools/erlang.bzl
@@ -4,10 +4,6 @@ load(
     "erlang_external",
 )
 load(
-    ":erlang_headers.bzl",
-    "erlang_headers",
-)
-load(
     ":erlang_toolchain.bzl",
     "erlang_toolchain",
 )
@@ -47,6 +43,7 @@ def erlang_toolchain_external():
 
 def erlang_toolchain_from_http_archive(
         name_suffix = "",
+        version = None,
         url = None,
         strip_prefix = None,
         sha256 = None,
@@ -54,6 +51,7 @@ def erlang_toolchain_from_http_archive(
         erlang_constraint = None):
     erlang_build(
         name = "otp{}".format(name_suffix),
+        version = version,
         url = url,
         strip_prefix = strip_prefix,
         sha256 = sha256,
@@ -93,6 +91,7 @@ def erlang_toolchain_from_github_release(
     )
     erlang_toolchain_from_http_archive(
         name_suffix = name_suffix,
+        version = version,
         url = url,
         strip_prefix = "otp_src_{}".format(version),
         sha256 = sha256,

--- a/tools/erlang.bzl
+++ b/tools/erlang.bzl
@@ -24,6 +24,7 @@ def erlang_toolchain_external():
     erlang_toolchain(
         name = "erlang_external",
         otp = ":otp_external",
+        visibility = ["//visibility:public"],
     )
 
     native.toolchain(
@@ -64,6 +65,7 @@ def erlang_toolchain_from_http_archive(
     erlang_toolchain(
         name = "erlang{}".format(name_suffix),
         otp = ":otp{}".format(name_suffix),
+        visibility = ["//visibility:public"],
     )
 
     native.toolchain(

--- a/tools/erlang_toolchain.bzl
+++ b/tools/erlang_toolchain.bzl
@@ -4,10 +4,18 @@ load(
 )
 
 def _impl(ctx):
-    toolchain_info = platform_common.ToolchainInfo(
-        otpinfo = ctx.attr.otp[OtpInfo],
-    )
-    return [toolchain_info]
+    otpinfo = ctx.attr.otp[OtpInfo]
+    vars = {
+        "OTP_VERSION": otpinfo.version,
+        "ERLANG_HOME": otpinfo.erlang_home,
+    }
+    if otpinfo.release_dir != None:
+        vars["ERLANG_RELEASE_DIR_PATH"] = otpinfo.release_dir.path
+        vars["ERLANG_RELEASE_DIR_SHORT_PATH"] = otpinfo.release_dir.short_path
+    return [
+        platform_common.ToolchainInfo(otpinfo = otpinfo),
+        platform_common.TemplateVariableInfo(vars),
+    ]
 
 erlang_toolchain = rule(
     implementation = _impl,
@@ -17,7 +25,10 @@ erlang_toolchain = rule(
             providers = [OtpInfo],
         ),
     },
-    provides = [platform_common.ToolchainInfo],
+    provides = [
+        platform_common.ToolchainInfo,
+        platform_common.TemplateVariableInfo,
+    ],
 )
 
 def _build_info(ctx):


### PR DESCRIPTION
This allows erlang_toolchain instances to be used with genrule and
similar rules to inject the following "make" variables:

- OTP_VERSION
- ERLANG_HOME
- ERLANG_RELEASE_DIR_PATH (not available with external erlang)
- ERLANG_RELEASE_DIR_SHORT_PATH (not available with external erlang)