### PR TITLE
Allow configuration of "static" external erlangs on the host

### DIFF
--- a/presubmit.yml
+++ b/presubmit.yml
@@ -14,10 +14,27 @@ tasks:
     - ./kerl update releases
     - ./kerl build ${ERLANG_VERSION}
     - ./kerl install ${ERLANG_VERSION} ~/kerl/${ERLANG_VERSION}
+    - ERLANG_HOME="$(realpath ~/kerl/${ERLANG_VERSION})"
     - |
-        export ERLANG_HOME="$(realpath ~/kerl/${ERLANG_VERSION})"
+        cat << EOF >> $(ls MODULE*)
+        erlang_config_extension = use_extension(
+            "@rules_erlang//bzlmod:extensions.bzl",
+            "erlang_config",
+        )
+
+        erlang_config_extension.external_erlang_from_path(
+            name = "static",
+            version = "${ERLANG_VERSION}",
+            erlang_home = "${ERLANG_HOME}",
+        )
+
+        use_repo(
+            erlang_config_extension,
+            "erlang_config",
+        )
+        EOF
     build_flags:
     - --incompatible_strict_action_env
-    - --extra_toolchains=@erlang_config//external:toolchain
+    - --extra_toolchains=@erlang_config//static:toolchain
     build_targets:
     - '@rules_erlang//...'

--- a/repositories/erlang_config.bzl
+++ b/repositories/erlang_config.bzl
@@ -6,73 +6,62 @@ load(
 ERLANG_HOME_ENV_VAR = "ERLANG_HOME"
 DEFAULT_ERL_PATH = "/usr/bin/erl"
 
-_EXTERNAL_ERLANG_PACKAGE = "external"
+_DEFAULT_EXTERNAL_ERLANG_PACKAGE_NAME = "external"
+
+INSTALLATION_TYPE_EXTERNAL = "external"
+INSTALLATION_TYPE_INTERNAL = "internal"
 
 def _impl(repository_ctx):
     rules_erlang_workspace = repository_ctx.attr.rules_erlang_workspace
 
-    erlang_installations = {}
-
-    if ERLANG_HOME_ENV_VAR in repository_ctx.os.environ:
-        erlang_home = repository_ctx.os.environ[ERLANG_HOME_ENV_VAR]
-    else:
-        if repository_ctx.os.name.find("windows") > 0:
-            erl_path = repository_ctx.which("erl.exe")
-        else:
-            erl_path = repository_ctx.which("erl")
-        if erl_path == None:
-            erl_path = repository_ctx.path(DEFAULT_ERL_PATH)
-        erlang_home = str(erl_path.dirname.dirname)
-
-    erl_path = path_join(erlang_home, "bin", "erl")
-    version = repository_ctx.execute(
-        [
-            erl_path,
-            "-noshell",
-            "-eval",
-            '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().',
-        ],
-        timeout = 10,
-    )
-    if version.return_code == 0:
-        erlang_version = version.stdout.strip("\n")
-        (major, _, _) = erlang_version.partition(".")
-        erlang_installations[_EXTERNAL_ERLANG_PACKAGE] = major
-        repository_ctx.template(
-            "{}/BUILD.bazel".format(_EXTERNAL_ERLANG_PACKAGE),
-            Label("//repositories:BUILD_external.tpl"),
-            {
-                "%{ERLANG_HOME}": erlang_home,
-                "%{ERLANG_VERSION}": erlang_version,
-                "%{ERLANG_MAJOR}": major,
-                "%{RULES_ERLANG_WORKSPACE}": rules_erlang_workspace,
-            },
-            False,
-        )
-
-    for name in repository_ctx.attr.versions.keys():
-        if name == _EXTERNAL_ERLANG_PACKAGE:
-            fail("'{}' is not allowed as an internal erlang name".format(
-                _EXTERNAL_ERLANG_PACKAGE,
+    erlang_installations = _default_erlang_dict(repository_ctx)
+    for name in repository_ctx.attr.types.keys():
+        if name == _DEFAULT_EXTERNAL_ERLANG_PACKAGE_NAME:
+            fail("'{}' is reserved as an erlang name".format(
+                _DEFAULT_EXTERNAL_ERLANG_PACKAGE_NAME,
             ))
-
-        version = repository_ctx.attr.versions.get(name)
+        version = repository_ctx.attr.versions[name]
         (major, _, _) = version.partition(".")
-        erlang_installations[name] = major
-
-        repository_ctx.template(
-            "{}/BUILD.bazel".format(name),
-            Label("//repositories:BUILD_internal.tpl"),
-            {
-                "%{ERLANG_VERSION}": version,
-                "%{URL}": repository_ctx.attr.urls.get(name),
-                "%{STRIP_PREFIX}": repository_ctx.attr.strip_prefixs.get(name, ""),
-                "%{SHA_256}": repository_ctx.attr.sha256s.get(name, ""),
-                "%{ERLANG_MAJOR}": major,
-                "%{RULES_ERLANG_WORKSPACE}": rules_erlang_workspace,
-            },
-            False,
+        erlang_installations[name] = struct(
+            type = repository_ctx.attr.types[name],
+            version = version,
+            major = major,
+            url = repository_ctx.attr.urls.get(name, None),
+            strip_prefix = repository_ctx.attr.strip_prefixs.get(name, None),
+            sha256 = repository_ctx.attr.sha256s.get(name, None),
+            erlang_home = repository_ctx.attr.erlang_homes.get(name, None),
         )
+
+    for (name, props) in erlang_installations.items():
+        if props.type == INSTALLATION_TYPE_EXTERNAL:
+            repository_ctx.template(
+                "{}/BUILD.bazel".format(name),
+                Label("//repositories:BUILD_external.tpl"),
+                {
+                    "%{ERLANG_HOME}": props.erlang_home,
+                    "%{ERLANG_VERSION}": props.version,
+                    "%{ERLANG_MAJOR}": props.major,
+                    "%{RULES_ERLANG_WORKSPACE}": rules_erlang_workspace,
+                },
+                False,
+            )
+        else:
+            repository_ctx.template(
+                "{}/BUILD.bazel".format(name),
+                Label("//repositories:BUILD_internal.tpl"),
+                {
+                    "%{ERLANG_VERSION}": props.version,
+                    "%{URL}": props.url,
+                    "%{STRIP_PREFIX}": props.strip_prefix or "",
+                    "%{SHA_256}": props.sha256 or "",
+                    "%{ERLANG_MAJOR}": props.major,
+                    "%{RULES_ERLANG_WORKSPACE}": rules_erlang_workspace,
+                },
+                False,
+            )
+
+    if len(erlang_installations) == 0:
+        fail("No erlang installations configured")
 
     repository_ctx.file(
         "BUILD.bazel",
@@ -101,23 +90,67 @@ erlang_config = repository_rule(
     implementation = _impl,
     attrs = {
         "rules_erlang_workspace": attr.string(),
+        "types": attr.string_dict(),
         "versions": attr.string_dict(),
         "urls": attr.string_dict(),
         "strip_prefixs": attr.string_dict(),
         "sha256s": attr.string_dict(),
+        "erlang_homes": attr.string_dict(),
     },
     environ = [
         "ERLANG_HOME",
     ],
 )
 
-def _build_file_content(erlang_installations):
-    if _EXTERNAL_ERLANG_PACKAGE in erlang_installations:
-        default_internal_external = "external"
-        default_major = erlang_installations[_EXTERNAL_ERLANG_PACKAGE]
+def _default_erlang_dict(repository_ctx):
+    if ERLANG_HOME_ENV_VAR in repository_ctx.os.environ:
+        erlang_home = repository_ctx.os.environ[ERLANG_HOME_ENV_VAR]
     else:
-        default_internal_external = "internal"
-        default_major = erlang_installations[0]
+        if repository_ctx.os.name.find("windows") > 0:
+            erl_path = repository_ctx.which("erl.exe")
+        else:
+            erl_path = repository_ctx.which("erl")
+        if erl_path == None:
+            erl_path = repository_ctx.path(DEFAULT_ERL_PATH)
+        erlang_home = str(erl_path.dirname.dirname)
+
+    erl_path = path_join(erlang_home, "bin", "erl")
+    version = repository_ctx.execute(
+        [
+            erl_path,
+            "-noshell",
+            "-eval",
+            '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().',
+        ],
+        timeout = 10,
+    )
+    if version.return_code == 0:
+        version = version.stdout.strip("\n")
+        (major, _, _) = version.partition(".")
+        return {
+            _DEFAULT_EXTERNAL_ERLANG_PACKAGE_NAME: struct(
+                type = INSTALLATION_TYPE_EXTERNAL,
+                version = version,
+                major = major,
+                erlang_home = erlang_home,
+            ),
+        }
+    else:
+        return {}
+
+def _build_file_content(erlang_installations):
+    external_installations = {
+        name: props
+        for (name, props) in erlang_installations.items()
+        if props.type == INSTALLATION_TYPE_EXTERNAL
+    }
+
+    if _DEFAULT_EXTERNAL_ERLANG_PACKAGE_NAME in erlang_installations:
+        default_installation = erlang_installations[_DEFAULT_EXTERNAL_ERLANG_PACKAGE_NAME]
+    elif len(external_installations) > 0:
+        default_installation = external_installations[0]
+    else:
+        default_installation = erlang_installations[0]
 
     build_file_content = """\
 package(
@@ -135,17 +168,12 @@ constraint_setting(
 )
 
 """.format(
-        default_internal_external = default_internal_external,
-        default_major = default_major,
+        default_internal_external = default_installation.type,
+        default_major = default_installation.major,
     )
 
-    should_have_external = False
-    should_have_internal = False
-    if _EXTERNAL_ERLANG_PACKAGE in erlang_installations:
-        should_have_external = True
-        should_have_internal = len(erlang_installations) > 1
-    else:
-        should_have_internal = len(erlang_installations) > 0
+    should_have_external = len(external_installations) > 0
+    should_have_internal = len(erlang_installations) > len(external_installations)
 
     if should_have_external:
         build_file_content += """\
@@ -166,8 +194,8 @@ constraint_value(
 """
 
     unique_majors = {
-        v: n
-        for (n, v) in erlang_installations.items()
+        props.major: name
+        for (name, props) in erlang_installations.items()
     }.keys()
     for major in unique_majors:
         build_file_content += """\

--- a/rules_erlang.bzl
+++ b/rules_erlang.bzl
@@ -4,6 +4,7 @@ load(
 )
 load(
     "//repositories:erlang_config.bzl",
+    "INSTALLATION_TYPE_INTERNAL",
     _erlang_config = "erlang_config",
 )
 load(
@@ -56,6 +57,7 @@ filegroup(
 def erlang_config(
         rules_erlang_workspace = "@rules_erlang",
         internal_erlang_configs = []):
+    types = {c.name: INSTALLATION_TYPE_INTERNAL for c in internal_erlang_configs}
     versions = {c.name: c.version for c in internal_erlang_configs}
     urls = {c.name: c.url for c in internal_erlang_configs}
     strip_prefixs = {c.name: c.strip_prefix for c in internal_erlang_configs if c.strip_prefix}
@@ -64,6 +66,7 @@ def erlang_config(
     _erlang_config(
         name = "erlang_config",
         rules_erlang_workspace = rules_erlang_workspace,
+        types = types,
         versions = versions,
         urls = urls,
         strip_prefixs = strip_prefixs,


### PR DESCRIPTION
This allows naming an explict external erlang in a projects MODULE.bazel

Primarily of use in BCR presubmit.yml where the `ERLANG_HOME` env var cannot be set