### PR TITLE
Always generate an external erlang in @erlang_config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,4 @@ build --incompatible_strict_action_env
 build --flag_alias=erlang_home=//:erlang_home
 build --flag_alias=erlang_version=//:erlang_version
 
-build --extra_toolchains=@erlang_config//external:toolchain
-
 try-import %workspace%/user.bazelrc

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,3 +34,7 @@ use_repo(
     erlang_config_extension,
     "erlang_config",
 )
+
+register_toolchains(
+    "@erlang_config//external:toolchain",
+)

--- a/repositories/erlang_config.bzl
+++ b/repositories/erlang_config.bzl
@@ -7,6 +7,7 @@ ERLANG_HOME_ENV_VAR = "ERLANG_HOME"
 DEFAULT_ERL_PATH = "/usr/bin/erl"
 
 _DEFAULT_EXTERNAL_ERLANG_PACKAGE_NAME = "external"
+_ERLANG_VERSION_UNKNOWN = "UNKNOWN"
 
 INSTALLATION_TYPE_EXTERNAL = "external"
 INSTALLATION_TYPE_INTERNAL = "internal"
@@ -136,7 +137,14 @@ def _default_erlang_dict(repository_ctx):
             ),
         }
     else:
-        return {}
+        return {
+            _DEFAULT_EXTERNAL_ERLANG_PACKAGE_NAME: struct(
+                type = INSTALLATION_TYPE_EXTERNAL,
+                version = _ERLANG_VERSION_UNKNOWN,
+                major = _ERLANG_VERSION_UNKNOWN.lower(),
+                erlang_home = erlang_home,
+            ),
+        }
 
 def _build_file_content(erlang_installations):
     external_installations = {

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -27,6 +27,5 @@ use_repo(
 )
 
 register_toolchains(
-    "@erlang_config//external:toolchain",
     "@erlang_config//internal:toolchain",
 )


### PR DESCRIPTION
Having predictable existence of the external erlang toolchain makes it more convienint to build modules on different machines