### PR TITLE
Allow overriding the strip-prefix arg for GitHub dependencies

### DIFF
--- a/github.bzl
+++ b/github.bzl
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load(":erlang_app.bzl", "DEFAULT_ERLC_OPTS")
 
 def github_erlang_app(
         name = None,
@@ -9,6 +10,8 @@ def github_erlang_app(
         extra_apps = [],
         deps = [],
         runtime_deps = [],
+        erlc_opts = DEFAULT_ERLC_OPTS,
+        strip_prefix = None,
         **kwargs):
     if not ("build_file" in kwargs.keys() or "build_file_content" in kwargs.keys()):
         kwargs.update(build_file_content = _BUILD_FILE_TEMPLATE.format(
@@ -17,15 +20,17 @@ def github_erlang_app(
             extra_apps = extra_apps,
             deps = deps,
             runtime_deps = runtime_deps,
+            erlc_opts = erlc_opts,
             stamp = 0,
         ))
 
     repo = name if repo == None else repo
+    strip_prefix = "{}-{}".format(repo, version) if strip_prefix == None else strip_prefix
 
     http_archive(
         name = name,
         urls = ["https://github.com/{}/{}/archive/{}.zip".format(org, repo, ref)],
-        strip_prefix = "{}-{}".format(repo, version),
+        strip_prefix = strip_prefix,
         **kwargs
     )
 
@@ -37,5 +42,6 @@ erlang_app(
     extra_apps = {extra_apps},
     deps = {deps},
     runtime_deps = {runtime_deps},
+    erlc_opts = {erlc_opts},
 )
 """


### PR DESCRIPTION
This is useful e.g. when depending on rebar3-monorepos, where the app that one might be interested in is nested in the directory structure.

An example of this structure is [opentelemetry](https://github.com/open-telemetry/opentelemetry-erlang):
```bazel
github_erlang_app(
    name = "opentelemetry_api_experimental",
    repo = "opentelemetry-erlang",
    org = "open-telemetry",
    ref = "v1.0.0",
    version = "v1.0.0",
    strip_prefix = "opentelemetry-erlang-1.0.0/apps/opentelemetry_api_experimental",
    sha256 = "f9d4f0c386610460e2f470117596e6300fa58a74ec1434b46431e86529f16c6b",
)

```