### PR TITLE
Allow overriding build file and app name for Hex apps

### DIFF
--- a/hex_pm.bzl
+++ b/hex_pm.bzl
@@ -4,20 +4,25 @@ load(":hex_archive.bzl", "hex_archive")
 def hex_pm_erlang_app(
         name = None,
         version = None,
+        app_name = None,
         erlc_opts = DEFAULT_ERLC_OPTS,
         deps = [],
         runtime_deps = [],
         **kwargs):
-    hex_archive(
-        name = name,
-        version = version,
-        build_file_content = _BUILD_FILE_TEMPLATE.format(
-            app_name = name,
+    if not ("build_file" in kwargs.keys() or "build_file_content" in kwargs.keys()):
+        if app_name == None:
+            app_name = name
+        kwargs.update(build_file_content = _BUILD_FILE_TEMPLATE.format(
+            app_name = app_name,
             version = version,
             erlc_opts = erlc_opts,
             deps = deps,
             runtime_deps = runtime_deps,
-        ),
+        ))
+
+    hex_archive(
+        name = name,
+        version = version,
         **kwargs
     )
 


### PR DESCRIPTION
It's useful to override the build file when pulling dependencies with a complicated build, e.g. [gpb](https://github.com/tomas-abrahamsson/gpb), and the app name for the cases when the package name is different from the name of the Erlang app, and the `$package.app` build product is not in a consistent location (this is convenient e.g. when building releases). One such app is `hpack`:

```bazel
hex_pm_erlang_app(
    name = "hpack_erl",
    app_name = "hpack",
    version = "0.2.3",
    sha256 = "06f580167c4b8b8a6429040df36cc93bba6d571faeaec1b28816523379cbb23a",
)
```