### PR TITLE
Drop the +deterministic erlc flag when `-c dbg` is passed

### DIFF
--- a/bzlmod/erlang_package.bzl
+++ b/bzlmod/erlang_package.bzl
@@ -246,10 +246,10 @@ erlang_app(
     $(if $(LOCAL_DEPS),extra_apps = [$(foreach dep,$(LOCAL_DEPS),\n        "$(dep)",)\n    ]$(comma))
     $(if $(BUILD_DEPS),build_deps = [$(foreach dep,$(BUILD_DEPS),\n        "@$(dep)//:erlang_app",)\n    ]$(comma))
     $(if $(DEPS),deps = [$(foreach dep,$(DEPS),\n        "@$(dep)//:erlang_app",)\n    ]$(comma))
-    erlc_opts = [
-        "+deterministic",
-        "+debug_info",
-    ],
+    erlc_opts = select({{
+        "@rules_erlang//:debug_build": ["+debug_info"],
+        "//conditions:default": ["+deterministic", "+debug_info"],
+    }}),
     stamp = 0,
 )
 endef
@@ -278,10 +278,10 @@ load("@rules_erlang//:erlang_app.bzl", "erlang_app")
 erlang_app(
     app_name = "{name}",
     app_version = "{version}",
-    erlc_opts = [
-        "+deterministic",
-        "+debug_info",
-    ],
+    erlc_opts = select({{
+        "@rules_erlang//:debug_build": ["+debug_info"],
+        "//conditions:default": ["+deterministic", "+debug_info"],
+    }}),
     deps = {deps},
     stamp = 0,
 )
@@ -299,10 +299,10 @@ load("@rules_erlang//:erlang_app.bzl", "erlang_app")
 erlang_app(
     app_name = "{name}",
     app_version = "{version}",
-    erlc_opts = [
-        "+deterministic",
-        "+debug_info",
-    ],
+    erlc_opts = select({{
+        "@rules_erlang//:debug_build": ["+debug_info"],
+        "//conditions:default": ["+deterministic", "+debug_info"],
+    }}),
     stamp = 0,
 )
 EOF
@@ -316,10 +316,10 @@ load("@rules_erlang//:erlang_app.bzl", "erlang_app")
 
 erlang_app(
     app_name = "{name}",
-    erlc_opts = [
-        "+deterministic",
-        "+debug_info",
-    ],
+    erlc_opts = select({{
+        "@rules_erlang//:debug_build": ["+debug_info"],
+        "//conditions:default": ["+deterministic", "+debug_info"],
+    }}),
     stamp = 0,
 )
 EOF

--- a/erlang_app.bzl
+++ b/erlang_app.bzl
@@ -5,6 +5,10 @@ load(
     "erlang_app_info",
     _ErlangAppInfo = "ErlangAppInfo",
 )
+load(
+    ":util.bzl",
+    "without",
+)
 
 DEFAULT_ERLC_OPTS = [
     "-Werror",
@@ -35,7 +39,10 @@ def erlang_app(
         app_env = "",
         app_extra_keys = "",
         extra_apps = [],
-        erlc_opts = DEFAULT_ERLC_OPTS,
+        erlc_opts = select({
+            Label("@rules_erlang//:debug_build"): without("+deterministic", DEFAULT_ERLC_OPTS),
+            "//conditions:default": DEFAULT_ERLC_OPTS,
+        }),
         extra_hdrs = [],
         extra_srcs = [],
         extra_priv = [],
@@ -98,7 +105,10 @@ def test_erlang_app(
         app_env = "",
         app_extra_keys = "",
         extra_apps = [],
-        erlc_opts = DEFAULT_TEST_ERLC_OPTS,
+        erlc_opts = select({
+            Label("@rules_erlang//:debug_build"): without("+deterministic", DEFAULT_TEST_ERLC_OPTS),
+            "//conditions:default": DEFAULT_TEST_ERLC_OPTS,
+        }),
         extra_hdrs = [],
         extra_srcs = [],
         extra_priv = [],


### PR DESCRIPTION
This allows code recompile and reload in the erlang shell