### PR TITLE
Simply the erlang version constraints into a single setting

### DIFF
--- a/repositories/BUILD_external.tpl
+++ b/repositories/BUILD_external.tpl
@@ -26,7 +26,8 @@ toolchain(
     exec_compatible_with = [
         "//:erlang_external",
     ],
-    target_compatible_with = [%{TARGET_COMPATIBLE_WITH}
+    target_compatible_with = [
+        "%{TARGET_COMPATIBLE_WITH}",
     ],
     toolchain = ":erlang",
     toolchain_type = "%{RULES_ERLANG_WORKSPACE}//tools:toolchain_type",

--- a/repositories/BUILD_internal.tpl
+++ b/repositories/BUILD_internal.tpl
@@ -28,7 +28,8 @@ toolchain(
     exec_compatible_with = [
         "//:erlang_internal",
     ],
-    target_compatible_with = [%{TARGET_COMPATIBLE_WITH}
+    target_compatible_with = [
+        "%{TARGET_COMPATIBLE_WITH}",
     ],
     toolchain = ":erlang",
     toolchain_type = "%{RULES_ERLANG_WORKSPACE}//tools:toolchain_type",


### PR DESCRIPTION
Fold `@erlang_config//:erlang_major_version` & `@erlang_config//:erlang_major_minor_version` into `@erlang_config//:erlang_version`

This may be a breaking change for those that use the underlying constraint values directly, but it also removes unnecessary duplication.