### PR TITLE
Include src/*.hrl files in the source_tree rule's output

### DIFF
--- a/erlang_app.bzl
+++ b/erlang_app.bzl
@@ -52,10 +52,11 @@ def erlang_app(
         runtime_deps = [],
         stamp = -1):
     srcs = native.glob(["src/**/*.erl"]) + extra_srcs
+    hdrs = native.glob(["include/**/*.hrl", "src/**/*.hrl"]) + extra_hdrs
 
     erlang_bytecode(
         name = "beam_files",
-        hdrs = native.glob(["include/**/*.hrl", "src/**/*.hrl"]) + extra_hdrs,
+        hdrs = hdrs,
         srcs = srcs,
         erlc_opts = erlc_opts,
         dest = "ebin",
@@ -91,7 +92,7 @@ def erlang_app(
         beam = [":beam_files"],
         priv = native.glob(["priv/**/*"]) + extra_priv,
         license_files = native.glob(["LICENSE*"]) + extra_license_files,
-        srcs = srcs,
+        srcs = hdrs + srcs,
         deps = deps + runtime_deps,
         visibility = ["//visibility:public"],
     )

--- a/erlang_app.bzl
+++ b/erlang_app.bzl
@@ -51,8 +51,14 @@ def erlang_app(
         deps = [],
         runtime_deps = [],
         stamp = -1):
-    srcs = native.glob(["src/**/*.erl"]) + extra_srcs
-    hdrs = native.glob(["include/**/*.hrl", "src/**/*.hrl"]) + extra_hdrs
+    srcs = native.glob(
+        ["src/**/*.erl"],
+        exclude = extra_srcs,
+    ) + extra_srcs
+    hdrs = native.glob(
+        ["include/**/*.hrl", "src/**/*.hrl"],
+        exclude = extra_hdrs,
+    ) + extra_hdrs
 
     erlang_bytecode(
         name = "beam_files",
@@ -87,11 +93,20 @@ def erlang_app(
     erlang_app_info(
         name = "erlang_app",
         app_name = app_name,
-        hdrs = native.glob(["include/**/*.hrl"]) + extra_hdrs,
+        hdrs = native.glob(
+            ["include/**/*.hrl"],
+            exclude = extra_hdrs,
+        ) + extra_hdrs,
         app = app,
         beam = [":beam_files"],
-        priv = native.glob(["priv/**/*"]) + extra_priv,
-        license_files = native.glob(["LICENSE*"]) + extra_license_files,
+        priv = native.glob(
+            ["priv/**/*"],
+            exclude = extra_priv,
+        ) + extra_priv,
+        license_files = native.glob(
+            ["LICENSE*"],
+            exclude = extra_license_files,
+        ) + extra_license_files,
         srcs = hdrs + srcs,
         deps = deps + runtime_deps,
         visibility = ["//visibility:public"],
@@ -117,11 +132,18 @@ def test_erlang_app(
         build_deps = [],
         deps = [],
         runtime_deps = []):
-    srcs = native.glob(["src/**/*.erl"]) + extra_srcs
+    srcs = native.glob(
+        ["src/**/*.erl"],
+        exclude = extra_srcs,
+    ) + extra_srcs
+    hdrs = native.glob(
+        ["include/**/*.hrl", "src/**/*.hrl"],
+        exclude = extra_hdrs,
+    ) + extra_hdrs
 
     erlang_bytecode(
         name = "test_beam_files",
-        hdrs = native.glob(["include/**/*.hrl", "src/**/*.hrl"]) + extra_hdrs,
+        hdrs = hdrs,
         srcs = srcs,
         erlc_opts = erlc_opts,
         dest = "test",
@@ -137,12 +159,15 @@ def test_erlang_app(
     erlang_app_info(
         name = "test_erlang_app",
         app_name = app_name,
-        hdrs = native.glob(["include/**/*.hrl", "src/**/*.hrl"]) + extra_hdrs,
+        hdrs = hdrs,
         app = app,
         beam = [":test_beam_files"],
         priv = native.glob(["priv/**/*"]) + extra_priv,
-        license_files = native.glob(["LICENSE*"]) + extra_license_files,
-        srcs = srcs,
+        license_files = native.glob(
+            ["LICENSE*"],
+            exclude = extra_license_files,
+        ) + extra_license_files,
+        srcs = hdrs + srcs,
         deps = deps + runtime_deps,
         visibility = ["//visibility:public"],
         testonly = True,

--- a/private/source_tree.bzl
+++ b/private/source_tree.bzl
@@ -19,7 +19,7 @@ def _impl(ctx):
     for dep in deps:
         lib_info = dep[ErlangAppInfo]
         dep_path = path_join(ctx.label.name, lib_info.app_name)
-        for src in lib_info.include + lib_info.srcs + lib_info.priv + lib_info.license_files:
+        for src in lib_info.srcs + lib_info.priv + lib_info.license_files:
             rp = additional_file_dest_relative_path(dep.label, src)
             dest = ctx.actions.declare_file(path_join(dep_path, rp))
             ctx.actions.symlink(output = dest, target_file = src)


### PR DESCRIPTION
This was an oversight in the original `source_tree` implementation.

Possibly `srcs` is less accurate a label in `ErlangAppInfo` as a consequence, though this allows to change to be non-breaking.