### PR TITLE
Add `untar` rule

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,9 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-        - "23.3"
         - "24.3"
-        - "25.0"
+        - "25.1"
     steps:
     - name: CHECKOUT
       uses: actions/checkout@v2
@@ -45,9 +44,8 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-        - "23.3"
         - "24.3"
-        - "25.0"
+        - "25.1"
     steps:
     - name: CHECKOUT
       uses: actions/checkout@v2
@@ -92,9 +90,8 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-        - "23.3"
         - "24.3"
-        - "25.0"
+        - "25.1"
     steps:
     - name: CHECKOUT
       uses: actions/checkout@v2
@@ -117,6 +114,40 @@ jobs:
       with:
         name: bazel-testlogs-bzlmod-${{matrix.otp}}
         path: ${{ steps.resolve-test-logs-path.outputs.LOGS_PATH }}/*
+  test-bzlmod-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        otp:
+        - "25.1"
+    steps:
+    - name: CHECKOUT
+      uses: actions/checkout@v2
+    - name: CONFIGURE ERLANG
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ matrix.otp }}
+    - name: CONFIGURE BAZEL
+      working-directory: test
+      shell: bash
+      run: |
+        cat << EOF >> user.bazelrc
+          startup --windows_enable_symlinks
+          build --enable_runfiles
+          build --color=yes
+        EOF
+    - name: TEST
+      working-directory: test
+      shell: cmd
+      run: |
+        where erl > tmpFile
+        set /p ERL_PATH= < tmpFile
+        del tmpFile
+
+        set ERLANG_HOME=%ERL_PATH:\bin\erl.exe=%
+
+        bazelisk test //...
   test-bzlmod-internal-erlang:
     runs-on: ubuntu-latest
     steps:

--- a/bzlmod/erlang_package.bzl
+++ b/bzlmod/erlang_package.bzl
@@ -39,7 +39,7 @@ GitPackage = provider(fields = [
 ])
 
 def log(ctx, msg):
-    ctx.execute([ctx.which("echo"), "RULES_ERLANG: " + msg], timeout = 1, quiet = False)
+    ctx.execute(["echo", "RULES_ERLANG: " + msg], timeout = 1, quiet = False)
 
 def hex_tree(
         ctx,

--- a/untar.bzl
+++ b/untar.bzl
@@ -1,0 +1,40 @@
+load(":util.bzl", "path_join")
+
+def _impl(ctx):
+    outputs = [
+        ctx.actions.declare_file(f.name)
+        for f in ctx.attr.outs
+    ]
+
+    args = ctx.actions.args()
+    args.add("-x")
+    args.add("--file")
+    args.add(ctx.file.archive)
+    args.add("--directory")
+    args.add(path_join(
+        ctx.bin_dir.path,
+        ctx.label.workspace_root,
+        ctx.label.package,
+    ))
+
+    ctx.actions.run(
+        outputs = outputs,
+        inputs = ctx.files.archive,
+        executable = "tar",
+        arguments = [args],
+    )
+
+    return [DefaultInfo(files = depset(outputs))]
+
+untar = rule(
+    implementation = _impl,
+    attrs = {
+        "archive": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "outs": attr.output_list(
+            mandatory = True,
+        ),
+    },
+)


### PR DESCRIPTION
This rule is useful for constructing BUILD files for hex.pm tarballs, and for adding the packages to a bazel registry for bzlmod.