### PR TITLE
Rework erlang version constraints

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,4 +37,5 @@ use_repo(
 
 register_toolchains(
     "@erlang_config//external:toolchain",
+    "@erlang_config//external:toolchain2",
 )

--- a/repositories/BUILD_external.tpl
+++ b/repositories/BUILD_external.tpl
@@ -27,7 +27,20 @@ toolchain(
         "//:erlang_external",
     ],
     target_compatible_with = [
-        "%{TARGET_COMPATIBLE_WITH}",
+        "//:erlang_%{ERLANG_MAJOR}",
+    ],
+    toolchain = ":erlang",
+    toolchain_type = "%{RULES_ERLANG_WORKSPACE}//tools:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "toolchain2",
+    exec_compatible_with = [
+        "//:erlang_external",
+    ],
+    target_compatible_with = [
+        "//:erlang_%{ERLANG_MAJOR}_%{ERLANG_MINOR}",
     ],
     toolchain = ":erlang",
     toolchain_type = "%{RULES_ERLANG_WORKSPACE}//tools:toolchain_type",

--- a/repositories/BUILD_internal.tpl
+++ b/repositories/BUILD_internal.tpl
@@ -29,7 +29,20 @@ toolchain(
         "//:erlang_internal",
     ],
     target_compatible_with = [
-        "%{TARGET_COMPATIBLE_WITH}",
+        "//:erlang_%{ERLANG_MAJOR}",
+    ],
+    toolchain = ":erlang",
+    toolchain_type = "%{RULES_ERLANG_WORKSPACE}//tools:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "toolchain2",
+    exec_compatible_with = [
+        "//:erlang_internal",
+    ],
+    target_compatible_with = [
+        "//:erlang_%{ERLANG_MAJOR}_%{ERLANG_MINOR}",
     ],
     toolchain = ":erlang",
     toolchain_type = "%{RULES_ERLANG_WORKSPACE}//tools:toolchain_type",

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -28,4 +28,5 @@ use_repo(
 
 register_toolchains(
     "@erlang_config//internal:toolchain",
+    "@erlang_config//internal:toolchain2",
 )


### PR DESCRIPTION
When support for multiple erlang majors with different minors was added, `selects.config_setting_group` instances were used to define platforms for an erlang major with any available minor.

Unfortunately in some cases this causes a cycle in the analysis graph to fail the analysis phase of some builds (probably depending on a host erlang's degree of overlap with internal
erlangs). See https://github.com/bazelbuild/bazel/issues/16452 for more details.

The downside is extra toolchains must be registered, but I don't see any alternatives.