### PR TITLE
Support for self-referencing `-include_lib` directives

### DIFF
--- a/erlang_app.bzl
+++ b/erlang_app.bzl
@@ -62,6 +62,7 @@ def erlang_app(
 
     erlang_bytecode(
         name = "beam_files",
+        app_name = app_name,
         hdrs = hdrs,
         srcs = srcs,
         erlc_opts = erlc_opts,
@@ -143,6 +144,7 @@ def test_erlang_app(
 
     erlang_bytecode(
         name = "test_beam_files",
+        app_name = app_name,
         hdrs = hdrs,
         srcs = srcs,
         erlc_opts = erlc_opts,

--- a/private/util.bzl
+++ b/private/util.bzl
@@ -21,8 +21,14 @@ def additional_file_dest_relative_path(dep_label, f):
     else:
         return f.short_path
 
-def erl_libs_contents2(ctx, deps = [], headers = False, dir = _DEFAULT_ERL_LIBS_DIR):
+def erl_libs_contents2(ctx, target_info = None, deps = [], headers = False, dir = _DEFAULT_ERL_LIBS_DIR):
     erl_libs_files = []
+    if headers and target_info != None:
+        dep_path = path_join(dir, target_info.app_name)
+        for hdr in target_info.include:
+            dest = ctx.actions.declare_file(path_join(dep_path, hdr.path))
+            ctx.actions.symlink(output = dest, target_file = hdr)
+            erl_libs_files.append(dest)
     for dep in deps:
         lib_info = dep[ErlangAppInfo]
         dep_path = path_join(dir, lib_info.app_name)


### PR DESCRIPTION
in the erlang_bytecode rule

The erlang_app macro will invoke erlang_bytecode in the correct manner to support this

erlang_bytecode in general need not be called specifically in the context of an application, so in this case the old behavior remains

Fixes #100 