### PR TITLE
Add @rules_erlang//tools:erlang_vars instance of erlang_vars rule

### DIFF
--- a/test/custom_vars/BUILD.bazel
+++ b/test/custom_vars/BUILD.bazel
@@ -3,12 +3,7 @@ genrule(
     srcs = [],
     outs = ["custom_var"],
     cmd = 'echo "OTP_VERSION: $(OTP_VERSION)" > $@',
-    # genrule toolchains are not resolved in the same manner of
-    # custom rules, so we simulate it with select in this case
-    toolchains = select({
-        "@erlang_config//:erlang_external": ["@erlang_config//external:erlang"],
-        "@erlang_config//:erlang_internal": ["@erlang_config//internal:erlang"],
-    }),
+    toolchains = ["@rules_erlang//tools:erlang_vars"],
 )
 
 sh_test(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:erlang_headers.bzl", "erlang_headers")
+load("//tools:erlang_vars.bzl", "erlang_vars")
 
 toolchain_type(
     name = "toolchain_type",
@@ -7,5 +8,10 @@ toolchain_type(
 
 erlang_headers(
     name = "erlang_headers",
+    visibility = ["//visibility:public"],
+)
+
+erlang_vars(
+    name = "erlang_vars",
     visibility = ["//visibility:public"],
 )

--- a/tools/erlang_toolchain.bzl
+++ b/tools/erlang_toolchain.bzl
@@ -27,6 +27,10 @@ erlang_toolchain = rule(
     },
     provides = [
         platform_common.ToolchainInfo,
+        # Instead of using this toolchain for a genrule,
+        # since toolchain resolution won't yet have applied,
+        # use @rules_erlang//tools:erlang_vars as a
+        # toolchain for genrule rules
         platform_common.TemplateVariableInfo,
     ],
 )

--- a/tools/erlang_vars.bzl
+++ b/tools/erlang_vars.bzl
@@ -1,0 +1,19 @@
+def _impl(ctx):
+    otpinfo = ctx.toolchains["//tools:toolchain_type"].otpinfo
+    vars = {
+        "OTP_VERSION": otpinfo.version,
+        "ERLANG_HOME": otpinfo.erlang_home,
+    }
+    if otpinfo.release_dir != None:
+        vars["ERLANG_RELEASE_DIR_PATH"] = otpinfo.release_dir.path
+        vars["ERLANG_RELEASE_DIR_SHORT_PATH"] = otpinfo.release_dir.short_path
+
+    return [platform_common.TemplateVariableInfo(vars)]
+
+erlang_vars = rule(
+    implementation = _impl,
+    provides = [
+        platform_common.TemplateVariableInfo,
+    ],
+    toolchains = ["//tools:toolchain_type"],
+)


### PR DESCRIPTION
`erlang_vars` is a new rule intended to be used as a toolchain for `genrule` instances, so that toolchain resolution does not need to be simulated with a `select`

`erlang_toolchain` rule instances should no longer be used for this purpose