### PR TITLE
Fixup actions test-host-erlang-change-detected

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -182,6 +182,10 @@ jobs:
     steps:
     - name: CHECKOUT
       uses: actions/checkout@v2
+    - name: CONFIGURE ERLANG
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: "25.0"
     - name: BUILD
       working-directory: test
       id: before


### PR DESCRIPTION
It seems that the github actions workers no longer have erlang by default?

Let's try using the erlef/setup-beam action twice and see what happens