### PR TITLE
Add ct_logdir build setting for ct_test rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,3 +21,9 @@ string_flag(
     build_setting_default = "",
     visibility = ["//visibility:public"],
 )
+
+string_flag(
+    name = "ct_logdir",
+    build_setting_default = "",
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,14 +1,13 @@
 module(
     name = "rules_erlang",
-    version = "3.8.4",
     compatibility_level = 3,
+    version = "3.8.4",
 )
 
 bazel_dep(
     name = "rules_pkg",
     version = "0.5.1",
 )
-
 bazel_dep(
     name = "bazel_skylib",
     version = "1.2.0",

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -7,7 +7,6 @@ bazel_dep(
     name = "platforms",
     version = "0.0.5",
 )
-
 bazel_dep(
     name = "rules_erlang",
     version = "3.0.0",


### PR DESCRIPTION
If set, will cause common test logs to be sent to the indicated path, instead of $TEST_UNDECLARED_OUTPUTS_DIR

While not useful with remote exection, it is convenient when executing locally