### PR TITLE
Add `libs` and `extra_args` attributes to the `plt` rule

### DIFF
--- a/dialyze.bzl
+++ b/dialyze.bzl
@@ -4,16 +4,24 @@ load(
 )
 load(
     "//private:plt.bzl",
-    _DEFAULT_PLT_APPS = "DEFAULT_PLT_APPS",
     _plt = "plt",
 )
 
-DEFAULT_PLT_APPS = _DEFAULT_PLT_APPS
+DEFAULT_PLT_APPS = ["erts", "kernel", "stdlib"]
 
 DIALYZE_TAG = "dialyze"
 
-def plt(**kwargs):
-    _plt(**kwargs)
+def plt(
+        for_target = None,
+        apps = None,
+        **kwargs):
+    if for_target == None and apps == None:
+        apps = DEFAULT_PLT_APPS
+    _plt(
+        for_target = for_target,
+        apps = apps,
+        **kwargs
+    )
 
 def dialyze(
         name = "dialyze",

--- a/private/erlang_bytecode2.bzl
+++ b/private/erlang_bytecode2.bzl
@@ -41,17 +41,14 @@ def _impl(ctx):
         dir = erl_libs_dir,
     )
 
-    # it would be nice to properly compute the path, but ctx.bin_dir.path
-    # does not appear to be the whole prefix
+    erl_libs_path = ""
     if len(erl_libs_files) > 0:
-        (output_dir, _, path) = erl_libs_files[0].path.partition(erl_libs_dir)
-        if output_dir == "":
-            fail("Could not compute the ERL_LIBS relative path from {}".format(
-                erl_libs_files[0].path,
-            ))
-        erl_libs_path = path_join(output_dir.rstrip("/"), erl_libs_dir)
-    else:
-        erl_libs_path = ""
+        erl_libs_path = path_join(
+            ctx.bin_dir.path,
+            ctx.label.workspace_root,
+            ctx.label.package,
+            erl_libs_dir,
+        )
 
     out_dirs = unique_dirnames(outputs)
     if len(out_dirs) > 1:

--- a/private/util.bzl
+++ b/private/util.bzl
@@ -21,7 +21,12 @@ def additional_file_dest_relative_path(dep_label, f):
     else:
         return f.short_path
 
-def erl_libs_contents2(ctx, target_info = None, deps = [], headers = False, dir = _DEFAULT_ERL_LIBS_DIR):
+def erl_libs_contents2(
+        ctx,
+        target_info = None,
+        deps = [],
+        headers = False,
+        dir = _DEFAULT_ERL_LIBS_DIR):
     erl_libs_files = []
     if headers and target_info != None:
         dep_path = path_join(dir, target_info.app_name)


### PR DESCRIPTION
libs are placed on the code path for erlang when the dialyzer command is run
This turns out to be useful with elixir, which needs to be on the code path to generate a plt from beam built with elixir

extra_args are just extra args to be passed to the `dialyzer` command