### PR TITLE
Support for deps declared as an atom in rebar.config files

### DIFF
--- a/gazelle/rebar_config_to_json.sh
+++ b/gazelle/rebar_config_to_json.sh
@@ -24,6 +24,9 @@ parse_json_string("\"" ++ Tail) ->
             string:reverse(Middle)
     end.
 
+mapify_dep(Name) when is_atom(Name) ->
+    #{name => Name,
+      kind => hex};
 mapify_dep({Name, _, {git = Kind, Remote, Ref}}) ->
     #{name => Name,
       kind => Kind,


### PR DESCRIPTION
e.g. `{deps, [getopt]}.`