### PR TITLE
Copy existing moduleindex.yaml during gazelle update-repos

### DIFF
--- a/gazelle/update.go
+++ b/gazelle/update.go
@@ -91,6 +91,15 @@ func ruleForHexPackage(config *config.Config, name, pkg, version string) (*rule.
 		)
 	}
 
+	rootIndexPath := filepath.Join(os.Getenv("BUILD_WORKSPACE_DIRECTORY"), "moduleindex.yaml")
+	moduleindexPath := filepath.Join(extractedPackageDir, "moduleindex.yaml")
+	if _, err := os.Stat(rootIndexPath); !os.IsNotExist(err) {
+		copyFile(
+			rootIndexPath,
+			moduleindexPath,
+		)
+	}
+
 	// TODO: Add an optional flag to tell update-repos what to recurse with.
 	//       Currently this only works if the rule that was used for update-repos
 	//       was called "gazelle" too
@@ -141,14 +150,10 @@ func ruleForHexPackage(config *config.Config, name, pkg, version string) (*rule.
 	r.SetAttr("version", version)
 	r.SetAttr("build_file", "@//:"+filepath.Join(erlangConfig.BuildFilesDir, buildFileName))
 
-	moduleindexPath := filepath.Join(extractedPackageDir, "moduleindex.yaml")
-	moduleindex, err := ReadModuleindex(moduleindexPath)
-	if err != nil {
-		return nil, err
-	}
-
-	rootIndexPath := filepath.Join(os.Getenv("BUILD_WORKSPACE_DIRECTORY"), "moduleindex.yaml")
-	err = MergeToModuleindex(rootIndexPath, moduleindex)
+	err = copyFile(
+		moduleindexPath,
+		rootIndexPath,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -278,6 +283,15 @@ func tryImportGithub(config *config.Config, imp string) (*rule.Rule, error) {
 		)
 	}
 
+	rootIndexPath := filepath.Join(os.Getenv("BUILD_WORKSPACE_DIRECTORY"), "moduleindex.yaml")
+	moduleindexPath := filepath.Join(extractedPackageDir, "moduleindex.yaml")
+	if _, err := os.Stat(rootIndexPath); !os.IsNotExist(err) {
+		copyFile(
+			rootIndexPath,
+			moduleindexPath,
+		)
+	}
+
 	// TODO: add an optional flag to tell update-repos what to recurse with
 	gazelleRunfile, err := bazel.Runfile("gazelle")
 	if err != nil {
@@ -328,14 +342,10 @@ func tryImportGithub(config *config.Config, imp string) (*rule.Rule, error) {
 	r.SetAttr("version", version)
 	r.SetAttr("build_file", "@//:"+filepath.Join(erlangConfig.BuildFilesDir, buildFileName))
 
-	moduleindexPath := filepath.Join(extractedPackageDir, "moduleindex.yaml")
-	moduleindex, err := ReadModuleindex(moduleindexPath)
-	if err != nil {
-		return nil, err
-	}
-
-	rootIndexPath := filepath.Join(os.Getenv("BUILD_WORKSPACE_DIRECTORY"), "moduleindex.yaml")
-	err = MergeToModuleindex(rootIndexPath, moduleindex)
+	err = copyFile(
+		moduleindexPath,
+		rootIndexPath,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/gazelle/update.go
+++ b/gazelle/update.go
@@ -158,8 +158,6 @@ func ruleForHexPackage(config *config.Config, name, pkg, version string) (*rule.
 		return nil, err
 	}
 
-	defer os.RemoveAll(downloadDir)
-
 	return r, nil
 }
 
@@ -349,8 +347,6 @@ func tryImportGithub(config *config.Config, imp string) (*rule.Rule, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	defer os.RemoveAll(downloadDir)
 
 	return r, nil
 }


### PR DESCRIPTION
The `moduleindex.yaml` keeps a record of which applications contain which modules, which, for instance, allows a behaviour to be resolved from known deps, without needing an explicit `#gazelle erlang_behaviour_source_lib` directive.

Therefore, when a repo is downloaded during gazelle update-repos, the existing moduleindex.yaml must be copied into the tempdir before recursively running gazelle