### PR TITLE
Gazelle: allow `vsn` that is not a string in `.app.src` files

### DIFF
--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -1,7 +1,10 @@
 load("@bazel_gazelle//:def.bzl", "gazelle_binary")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-exports_files(["erl_attrs_to_json.sh"])
+exports_files([
+    "dot_app_to_json.sh",
+    "erl_attrs_to_json.sh",
+])
 
 go_library(
     name = "gazelle",

--- a/gazelle/dot_app_parser.go
+++ b/gazelle/dot_app_parser.go
@@ -113,8 +113,8 @@ func (p *dotAppParser) parseAppSrc(appFile string) (*dotApp, error) {
 type dotApp map[string]dotAppProps
 
 type dotAppProps struct {
-	Description  string   `json:"description"`
-	Vsn          string   `json:"vsn"`
-	Licenses     []string `json:"licenses"`
-	Applications []string `json:"applications"`
+	Description  string      `json:"description"`
+	Vsn          interface{} `json:"vsn"`
+	Licenses     []string    `json:"licenses"`
+	Applications []string    `json:"applications"`
 }

--- a/gazelle/dot_app_to_json.sh
+++ b/gazelle/dot_app_to_json.sh
@@ -5,6 +5,10 @@
 
 -export([main/1]).
 
+-ifdef(TEST).
+-export([parse/1]).
+-endif.
+
 main(Args) ->
     case io:get_line("") of
         eof ->
@@ -40,8 +44,10 @@ conform(List) ->
         fun
             (description, Desc) ->
                 list_to_binary(Desc);
-            (vsn, Vsn) ->
+            (vsn, Vsn) when is_list(Vsn) ->
                 list_to_binary(Vsn);
+            (vsn, {cmd, Cmd}) when is_list(Cmd) ->
+                #{<<"cmd">> => list_to_binary(Cmd)};
             (licenses, Licenses) ->
                 lists:map(fun list_to_binary/1, Licenses);
             (applications, Apps) ->

--- a/gazelle/fetch/BUILD.bazel
+++ b/gazelle/fetch/BUILD.bazel
@@ -3,8 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "fetch",
     srcs = [
-        "hex_pm.go",
         "github.go",
+        "hex_pm.go",
         "tar.go",
     ],
     importpath = "github.com/rabbitmq/rules_erlang/gazelle/fetch",

--- a/test/.bazelrc
+++ b/test/.bazelrc
@@ -12,6 +12,8 @@ build:buildbuddy --grpc_keepalive_time=360s
 build:buildbuddy --grpc_keepalive_timeout=360s
 build:buildbuddy --build_metadata=REPO_URL=https://github.com/rabbitmq/rules_erlang.git
 
+build:buildbuddy --@rules_erlang//:ct_logdir=
+
 build:rbe --config=buildbuddy
 
 build:rbe --remote_executor=grpcs://remote.buildbuddy.io

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,3 @@
 /bazel-*
 /user.bazelrc
+/logs/

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -56,3 +56,21 @@ register_toolchains(
     "@erlang_config//internal:toolchain",
     "@erlang_config//internal:toolchain2",
 )
+
+erlang_package = use_extension(
+    "@rules_erlang//bzlmod:extensions.bzl",
+    "erlang_package",
+    dev_dependency = True,
+)
+
+erlang_package.hex_package(
+    name = "thoas",
+    build_file = "@//dot_app_to_json:BUILD.thoas",
+    sha256 = "442296847aca11db8d25180693d7ca3073d6d7179f66952f07b16415306513b6",
+    version = "0.4.0",
+)
+
+use_repo(
+    erlang_package,
+    "thoas",
+)

--- a/test/WORKSPACE.bazel
+++ b/test/WORKSPACE.bazel
@@ -105,3 +105,12 @@ erlang_config(
 load("@erlang_config//:defaults.bzl", "register_defaults")
 
 register_defaults()
+
+load("@rules_erlang//:hex_pm.bzl", "hex_pm_erlang_app")
+
+hex_pm_erlang_app(
+    name = "thoas",
+    build_file = "@//dot_app_to_json:BUILD.thoas",
+    sha256 = "442296847aca11db8d25180693d7ca3073d6d7179f66952f07b16415306513b6",
+    version = "0.4.0",
+)

--- a/test/dot_app_to_json/BUILD.bazel
+++ b/test/dot_app_to_json/BUILD.bazel
@@ -33,21 +33,21 @@ load(
 
 genrule(
     name = "src",
-    srcs = ["@rules_erlang//gazelle:erl_attrs_to_json.sh"],
-    outs = ["src/erl_attrs_to_json.erl"],
+    srcs = ["@rules_erlang//gazelle:dot_app_to_json.sh"],
+    outs = ["src/dot_app_to_json.erl"],
     cmd = """\
-echo "-module(erl_attrs_to_json)." > $@
+echo "-module(dot_app_to_json)." > $@
 tail -n +4 $< >> $@
 """,
 )
 
-APP_NAME = "erl_attrs_to_json"
+APP_NAME = "dot_app_to_json"
 
 APP_VERSION = "1.0.0"
 
 erlang_bytecode(
     name = "beam_files",
-    srcs = ["src/erl_attrs_to_json.erl"],
+    srcs = ["src/dot_app_to_json.erl"],
     dest = "ebin",
     erlc_opts = DEFAULT_ERLC_OPTS,
 )
@@ -55,7 +55,7 @@ erlang_bytecode(
 erlang_bytecode(
     name = "test_beam_files",
     testonly = True,
-    srcs = ["src/erl_attrs_to_json.erl"],
+    srcs = ["src/dot_app_to_json.erl"],
     dest = "test",
     erlc_opts = DEFAULT_TEST_ERLC_OPTS + [
         "+nowarn_export_all",
@@ -70,7 +70,7 @@ app_file(
 
 erlang_app_info(
     name = "erlang_app",
-    srcs = ["src/erl_attrs_to_json.erl"],
+    srcs = ["src/dot_app_to_json.erl"],
     app = ":app_file",
     app_name = APP_NAME,
     beam = [":beam_files"],
@@ -79,7 +79,7 @@ erlang_app_info(
 erlang_app_info(
     name = "test_erlang_app",
     testonly = True,
-    srcs = ["src/erl_attrs_to_json.erl"],
+    srcs = ["src/dot_app_to_json.erl"],
     app = ":app_file",
     app_name = APP_NAME,
     beam = [":test_beam_files"],
@@ -97,10 +97,13 @@ dialyze(
 )
 
 ct_suite(
-    name = "erl_attrs_to_json_SUITE",
+    name = "dot_app_to_json_SUITE",
     size = "small",
     data = [
-        "test/basic.erl",
+        "test/basic.app.src",
+    ],
+    runtime_deps = [
+        "@thoas//:erlang_app",
     ],
 )
 

--- a/test/dot_app_to_json/BUILD.thoas
+++ b/test/dot_app_to_json/BUILD.thoas
@@ -1,0 +1,108 @@
+load("@rules_erlang//:erlang_bytecode2.bzl", "erlang_bytecode", "erlc_opts")
+load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+
+erlc_opts(
+    name = "erlc_opts",
+    values = select({
+        "@rules_erlang//:debug_build": [
+            "+debug_info",
+        ],
+        "//conditions:default": [
+            "+debug_info",
+            "+deterministic",
+        ],
+    }),
+    visibility = [":__subpackages__"],
+)
+
+erlang_bytecode(
+    name = "ebin_thoas_beam",
+    srcs = ["src/thoas.erl"],
+    outs = ["ebin/thoas.beam"],
+    app_name = "thoas",
+    erlc_opts = "//:erlc_opts",
+)
+
+erlang_bytecode(
+    name = "ebin_thoas_decode_beam",
+    srcs = ["src/thoas_decode.erl"],
+    outs = ["ebin/thoas_decode.beam"],
+    app_name = "thoas",
+    erlc_opts = "//:erlc_opts",
+)
+
+erlang_bytecode(
+    name = "ebin_thoas_encode_beam",
+    srcs = ["src/thoas_encode.erl"],
+    outs = ["ebin/thoas_encode.beam"],
+    app_name = "thoas",
+    erlc_opts = "//:erlc_opts",
+)
+
+filegroup(
+    name = "beam_files",
+    srcs = [
+        "ebin/thoas.beam",
+        "ebin/thoas_decode.beam",
+        "ebin/thoas_encode.beam",
+    ],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = [
+        "src/thoas.app.src",
+        "src/thoas.erl",
+        "src/thoas_decode.erl",
+        "src/thoas_encode.erl",
+    ],
+)
+
+filegroup(
+    name = "private_hdrs",
+    srcs = [],
+)
+
+filegroup(
+    name = "public_hdrs",
+    srcs = [],
+)
+
+filegroup(
+    name = "priv",
+    srcs = [],
+)
+
+filegroup(
+    name = "licenses",
+    srcs = ["LICENSE"],
+)
+
+filegroup(
+    name = "public_and_private_hdrs",
+    srcs = [
+        ":private_hdrs",
+        ":public_hdrs",
+    ],
+)
+
+filegroup(
+    name = "all_srcs",
+    srcs = [
+        ":public_and_private_hdrs",
+        ":srcs",
+    ],
+)
+
+erlang_app(
+    name = "erlang_app",
+    srcs = [":all_srcs"],
+    app_name = "thoas",
+    beam_files = [":beam_files"],
+)
+
+alias(
+    name = "thoas",
+    actual = ":erlang_app",
+    visibility = ["//visibility:public"],
+)

--- a/test/dot_app_to_json/test/basic.app.src
+++ b/test/dot_app_to_json/test/basic.app.src
@@ -1,0 +1,14 @@
+{application, basic,
+ [{description, "Basic App"},
+  {id, "basic"},
+  {vsn, {cmd, "git describe --tags --always"}},
+  {modules, []},
+  {registered, []},
+  {applications, [kernel, stdlib]},
+  {env, []},
+  {licenses, ["Apache-2.0"]},
+  {maintainers, ["RabbitMQ <info@rabbitmq.com>"]},
+  {links, [{"Homepage", "https://rabbitmq.com/"},
+           {"Github", "https://github.com/rabbitmq/rules_erlang"}
+          ]}
+ ]}.

--- a/test/dot_app_to_json/test/dot_app_to_json_SUITE.erl
+++ b/test/dot_app_to_json/test/dot_app_to_json_SUITE.erl
@@ -1,0 +1,31 @@
+-module(dot_app_to_json_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() -> [
+          basic
+         ].
+
+basic(_) ->
+    Json = dot_app_to_json:parse(fixture_path("test/basic.app.src")),
+    ct:pal(?LOW_IMPORTANCE, "Json: ~p", [Json]),
+    {ok, Parsed} = thoas:decode(Json),
+    ?assertMatch(
+       #{<<"basic">> :=
+             #{<<"applications">> :=
+                   [<<"kernel">>,<<"stdlib">>],
+               <<"description">> := <<"Basic App">>,
+               <<"licenses">> := [<<"Apache-2.0">>],
+               <<"vsn">> :=
+                   #{<<"cmd">> :=
+                         <<"git describe --tags --always">>}}},
+       Parsed).
+
+fixture_path(File) ->
+    filename:join([os:getenv("TEST_SRCDIR"),
+                   os:getenv("TEST_WORKSPACE"),
+                   "dot_app_to_json",
+                   File]).

--- a/test/gazelle/BUILD.bazel
+++ b/test/gazelle/BUILD.bazel
@@ -3,9 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 gazelle_binary(
     name = "gazelle_erlang_binary",
+    testonly = True,
     languages = ["@rules_erlang//gazelle"],
     tags = ["manual"],
-    testonly = True,
 )
 
 go_test(
@@ -18,24 +18,24 @@ go_test(
         "@rules_erlang//gazelle:hex_metadata_config_to_json",
         "@rules_erlang//gazelle:rebar_config_to_json",
     ] + glob(["testdata/**"]),
+    tags = ["manual"],
     deps = [
         "@bazel_gazelle//testtools:go_default_library",
         "@com_github_emirpasic_gods//lists/singlylinkedlist",
         "@com_github_ghodss_yaml//:yaml",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
-    tags = ["manual"],
 )
 
 go_test(
     name = "fetch_test",
     srcs = ["fetch_test.go"],
+    tags = ["manual"],
     deps = [
         "@com_github_onsi_ginkgo_v2//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
         "@rules_erlang//gazelle/fetch",
     ],
-    tags = ["manual"],
 )
 
 go_test(
@@ -44,30 +44,30 @@ go_test(
         "erlang_test.go",
         "fake_erl_parser.go",
     ],
+    tags = ["manual"],
     deps = [
-        "@com_github_onsi_ginkgo_v2//:go_default_library",
-        "@com_github_onsi_gomega//:go_default_library",
         "@bazel_gazelle//config:go_default_library",
         "@bazel_gazelle//language:go_default_library",
+        "@com_github_onsi_ginkgo_v2//:go_default_library",
+        "@com_github_onsi_gomega//:go_default_library",
         "@rules_erlang//gazelle",
     ],
-    tags = ["manual"],
 )
 
 test_suite(
     name = "unit_suite",
+    tags = ["manual"],
     tests = [
         "erlang_test",
         "fetch_test",
     ],
-    tags = ["manual"],
 )
 
 test_suite(
     name = "all_suites",
-    tests = [
-        "unit_suite",
-        "integration_suite",
-    ],
     tags = ["manual"],
+    tests = [
+        "integration_suite",
+        "unit_suite",
+    ],
 )

--- a/test/gazelle/erlang_test.go
+++ b/test/gazelle/erlang_test.go
@@ -31,6 +31,54 @@ var _ = Describe("an ErlangApp", func() {
 		app = erlang.NewErlangApp(args.Config.RepoRoot, args.Rel)
 	})
 
+	Describe("AddFile", func() {
+		BeforeEach(func() {
+			app.AddFile("src/foo.app.src")
+			app.AddFile("src/foo.erl")
+			app.AddFile("src/foo.hrl")
+			app.AddFile("include/bar.hrl")
+			app.AddFile("test/foo_SUITE.erl")
+			app.AddFile("priv/foo.img")
+			app.AddFile("LICENSE")
+			app.AddFile("src/bar.png")
+		})
+
+		It("puts .app.src files in AppSrc", func() {
+			Expect(app.AppSrc).To(HaveLen(1))
+			Expect(app.AppSrc.Contains("src/foo.app.src")).To(BeTrue())
+		})
+
+		It("puts src files in Srcs", func() {
+			Expect(app.Srcs).To(HaveLen(1))
+			Expect(app.Srcs.Contains("src/foo.erl")).To(BeTrue())
+		})
+
+		It("puts private hdrs in PrivateHdrs", func() {
+			Expect(app.PrivateHdrs).To(HaveLen(1))
+			Expect(app.PrivateHdrs.Contains("src/foo.hrl")).To(BeTrue())
+		})
+
+		It("puts public hdrs in PublicHdrs", func() {
+			Expect(app.PublicHdrs).To(HaveLen(1))
+			Expect(app.PublicHdrs.Contains("include/bar.hrl")).To(BeTrue())
+		})
+
+		It("puts test srcs in TestSrcs", func() {
+			Expect(app.TestSrcs).To(HaveLen(1))
+			Expect(app.TestSrcs.Contains("test/foo_SUITE.erl")).To(BeTrue())
+		})
+
+		It("puts priv in Priv", func() {
+			Expect(app.Priv).To(HaveLen(1))
+			Expect(app.Priv.Contains("priv/foo.img")).To(BeTrue())
+		})
+
+		It("puts license files in LicenseFiles", func() {
+			Expect(app.LicenseFiles).To(HaveLen(1))
+			Expect(app.LicenseFiles.Contains("LICENSE")).To(BeTrue())
+		})
+	})
+
 	Describe("BeamFilesRules", func() {
 		BeforeEach(func() {
 			app.AddFile("src/foo.erl")


### PR DESCRIPTION
It turns out that currently we do not use the value in gazelle anyway, as if a `.app.src` exists, the value is preserved at build time anyway, and isn't needed for the analysis phase