### PR TITLE
Run 'bazel update_go_deps'

### DIFF
--- a/gazelle/deps.bzl
+++ b/gazelle/deps.bzl
@@ -80,12 +80,6 @@ def gazelle_deps():
     )
 
     go_repository(
-        name = "com_github_emirpasic_gods",
-        importpath = "github.com/emirpasic/gods",
-        sum = "h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=",
-        version = "v1.18.1",
-    )
-    go_repository(
         name = "com_github_envoyproxy_go_control_plane",
         importpath = "github.com/envoyproxy/go-control-plane",
         sum = "h1:4cmBvAEBNJaGARUEs3/suWRyfyBfhf7I60WBZq+bv2w=",
@@ -104,12 +98,6 @@ def gazelle_deps():
         version = "v1.6.0",
     )
 
-    go_repository(
-        name = "com_github_ghodss_yaml",
-        importpath = "github.com/ghodss/yaml",
-        sum = "h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=",
-        version = "v1.0.0",
-    )
     go_repository(
         name = "com_github_golang_glog",
         importpath = "github.com/golang/glog",
@@ -211,8 +199,8 @@ def gazelle_deps():
     go_repository(
         name = "org_golang_x_crypto",
         importpath = "golang.org/x/crypto",
-        sum = "h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=",
-        version = "v0.1.0",
+        sum = "h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=",
+        version = "v0.0.0-20190308221718-c2843e01d9a2",
     )
 
     go_repository(


### PR DESCRIPTION
This was forgotten when the MODULE.bazel files were updated, as part of the moving of gazelle tests from the root to the tests directory