### PR TITLE
Rename erlang_behaviour_source_lib directive

### DIFF
--- a/gazelle/configure.go
+++ b/gazelle/configure.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	behaviourSourceDirective             = "erlang_behaviour_source_lib"
+	moduleSourceDirective                = "erlang_module_source_lib"
 	excludeWhenRuleOfKindExistsDirective = "erlang_exclude_when_rule_of_kind_exists"
 	generateBeamFilesMacroDirective      = "erlang_generate_beam_files_macro"
 	generateTestBeamUnconditionally      = "erlang_always_generate_test_beam_files"
@@ -82,7 +82,7 @@ type ErlangConfig struct {
 	NoTests                         bool
 	BuildFilesDir                   string
 	AppsDirs                        MutableSet[string]
-	BehaviourMappings               map[string]string
+	ModuleMappings                  map[string]string
 	ExcludeWhenRuleOfKindExists     MutableSet[string]
 	IgnoredDeps                     MutableSet[string]
 	GenerateBeamFilesMacro          bool
@@ -105,7 +105,7 @@ func (erlang *Configurer) defaultErlangConfig(rel string) *ErlangConfig {
 		NoTests:                         erlang.noTests,
 		BuildFilesDir:                   erlang.buildFilesDir,
 		AppsDirs:                        NewMutableSet(erlang.appsDir),
-		BehaviourMappings:               make(map[string]string),
+		ModuleMappings:                  make(map[string]string),
 		ExcludeWhenRuleOfKindExists:     NewMutableSet[string](),
 		IgnoredDeps:                     defaultIgnoredDeps,
 		GenerateBeamFilesMacro:          false,
@@ -135,7 +135,7 @@ func erlangConfigForRel(c *config.Config, rel string) *ErlangConfig {
 			NoTests:                         parentConfig.NoTests,
 			BuildFilesDir:                   parentConfig.BuildFilesDir,
 			AppsDirs:                        Copy(parentConfig.AppsDirs),
-			BehaviourMappings:               CopyMap(parentConfig.BehaviourMappings),
+			ModuleMappings:                  CopyMap(parentConfig.ModuleMappings),
 			ExcludeWhenRuleOfKindExists:     Copy(parentConfig.ExcludeWhenRuleOfKindExists),
 			IgnoredDeps:                     Copy(parentConfig.IgnoredDeps),
 			GenerateBeamFilesMacro:          parentConfig.GenerateBeamFilesMacro,
@@ -183,7 +183,7 @@ func (erlang *Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 
 func (erlang *Configurer) KnownDirectives() []string {
 	return []string{
-		behaviourSourceDirective,
+		moduleSourceDirective,
 		excludeWhenRuleOfKindExistsDirective,
 		generateBeamFilesMacroDirective,
 		generateSkipRules,
@@ -215,11 +215,11 @@ func (erlang *Configurer) Configure(c *config.Config, rel string, f *rule.File) 
 
 		for _, d := range f.Directives {
 			switch d.Key {
-			case behaviourSourceDirective:
+			case moduleSourceDirective:
 				parts := strings.Split(d.Value, ":")
 				behaviour := parts[0]
 				dep := parts[1]
-				erlangConfig.BehaviourMappings[behaviour] = dep
+				erlangConfig.ModuleMappings[behaviour] = dep
 			case excludeWhenRuleOfKindExistsDirective:
 				erlangConfig.ExcludeWhenRuleOfKindExists[d.Value] = true
 			case generateBeamFilesMacroDirective:

--- a/gazelle/erl_attrs_to_json.sh
+++ b/gazelle/erl_attrs_to_json.sh
@@ -130,6 +130,10 @@ record_expression(E, {'case', _, Arg, Expressions}) ->
     lists:foreach(
       fun (Expression) -> record_expression(E, Expression) end,
       Expressions);
+record_expression(E, {match, _, Lhs, Rhs} = _Match) ->
+    %% io:format(standard_error, "Match: ~p~n", [Match]),
+    record_expression(E, Lhs),
+    record_expression(E, Rhs);
 record_expression(_, _Exp) ->
     %% io:format(standard_error, "E: ~p~n", [Exp]),
     ok.

--- a/gazelle/erlang_app.go
+++ b/gazelle/erlang_app.go
@@ -236,42 +236,41 @@ func (erlangApp *ErlangApp) BeamFilesRules(args language.GenerateArgs, erlParser
 		}
 
 		theseBeam := NewMutableSet[string]()
-		for _, behaviour := range erlAttrs.modules() {
+		for _, module := range erlAttrs.modules() {
 			found := false
 			for _, other_src := range erlangApp.Srcs.Values(strings.Compare) {
-				if moduleName(other_src) == behaviour {
-					Log(args.Config, "            behaviour", behaviour, "->", beamFile(other_src))
+				if moduleName(other_src) == module {
+					Log(args.Config, "            module", module, "->", beamFile(src))
 					theseBeam.Add(beamFile(other_src))
 					found = true
 					break
 				}
 			}
-			if !found {
-				if dep, found := erlangConfig.ModuleMappings[behaviour]; found {
-					Log(args.Config, "            behaviour", behaviour, "->", fmt.Sprintf("%s:%s", dep, behaviour))
-					theseDeps.Add(dep)
-					found = true
-					break
-				}
+			if found {
+				continue
 			}
-			if !found {
-				if app := FindModule(moduleindex, behaviour); app != "" && app != erlangApp.Name {
-					Log(args.Config, "            behaviour", behaviour, "->", fmt.Sprintf("%s:%s", app, behaviour))
-					theseDeps.Add(app)
-					found = true
-					break
-				}
+			if dep, found := erlangConfig.ModuleMappings[module]; found {
+				Log(args.Config, "            module", module, "->", fmt.Sprintf("%s:%s", dep, module))
+				theseDeps.Add(dep)
+				continue
+			}
+			if app := FindModule(moduleindex, module); app != "" && app != erlangApp.Name {
+				Log(args.Config, "            module", module, "->", fmt.Sprintf("%s:%s", app, module))
+				theseDeps.Add(app)
+				continue
 			}
 		}
 
 		for module := range erlAttrs.Call {
-			if app := FindModule(moduleindex, module); app != "" && app != erlangApp.Name {
-				if !erlangConfig.IgnoredDeps.Contains(app) {
-					Log(args.Config, "            call", module, "->", app)
-					erlangApp.Deps.Add(app)
-				} else {
-					Log(args.Config, "            ignoring call", module, "->", app)
-				}
+			app := erlangConfig.ModuleMappings[module]
+			if app == "" {
+				app = FindModule(moduleindex, module)
+			}
+			if app != "" && app != erlangApp.Name && !erlangConfig.IgnoredDeps.Contains(app) {
+				Log(args.Config, "            call", module, "->", fmt.Sprintf("%s:%s", app, module))
+				erlangApp.Deps.Add(app)
+			} else {
+				Log(args.Config, "            ignoring call", module, "->", app)
 			}
 		}
 
@@ -363,42 +362,41 @@ func (erlangApp *ErlangApp) testBeamFilesRules(args language.GenerateArgs, erlPa
 		}
 
 		theseBeam := NewMutableSet[string]()
-		for _, behaviour := range erlAttrs.modules() {
+		for _, module := range erlAttrs.modules() {
 			found := false
 			for _, other_src := range erlangApp.Srcs.Values(strings.Compare) {
-				if moduleName(other_src) == behaviour {
-					Log(args.Config, "            behaviour", behaviour, "->", beamFile(src))
+				if moduleName(other_src) == module {
+					Log(args.Config, "            module", module, "->", beamFile(src))
 					theseBeam.Add(beamFile(other_src))
 					found = true
 					break
 				}
 			}
-			if !found {
-				if dep, found := erlangConfig.ModuleMappings[behaviour]; found {
-					Log(args.Config, "            behaviour", behaviour, "->", fmt.Sprintf("%s:%s", dep, behaviour))
-					theseDeps.Add(dep)
-					found = true
-					break
-				}
+			if found {
+				continue
 			}
-			if !found {
-				if app := FindModule(moduleindex, behaviour); app != "" && app != erlangApp.Name {
-					Log(args.Config, "            behaviour", behaviour, "->", fmt.Sprintf("%s:%s", app, behaviour))
-					theseDeps.Add(app)
-					found = true
-					break
-				}
+			if dep, found := erlangConfig.ModuleMappings[module]; found {
+				Log(args.Config, "            module", module, "->", fmt.Sprintf("%s:%s", dep, module))
+				theseDeps.Add(dep)
+				continue
+			}
+			if app := FindModule(moduleindex, module); app != "" && app != erlangApp.Name {
+				Log(args.Config, "            module", module, "->", fmt.Sprintf("%s:%s", app, module))
+				theseDeps.Add(app)
+				continue
 			}
 		}
 
 		for module := range erlAttrs.Call {
-			if app := FindModule(moduleindex, module); app != "" && app != erlangApp.Name {
-				if !erlangConfig.IgnoredDeps.Contains(app) {
-					Log(args.Config, "            call", module, "->", app)
-					erlangApp.Deps.Add(app)
-				} else {
-					Log(args.Config, "            ignoring call", module, "->", app)
-				}
+			app := erlangConfig.ModuleMappings[module]
+			if app == "" {
+				app = FindModule(moduleindex, module)
+			}
+			if app != "" && app != erlangApp.Name && !erlangConfig.IgnoredDeps.Contains(app) {
+				Log(args.Config, "            call", module, "->", fmt.Sprintf("%s:%s", app, module))
+				erlangApp.Deps.Add(app)
+			} else {
+				Log(args.Config, "            ignoring call", module, "->", app)
 			}
 		}
 

--- a/gazelle/erlang_app.go
+++ b/gazelle/erlang_app.go
@@ -247,7 +247,7 @@ func (erlangApp *ErlangApp) BeamFilesRules(args language.GenerateArgs, erlParser
 				}
 			}
 			if !found {
-				if dep, found := erlangConfig.BehaviourMappings[behaviour]; found {
+				if dep, found := erlangConfig.ModuleMappings[behaviour]; found {
 					Log(args.Config, "            behaviour", behaviour, "->", fmt.Sprintf("%s:%s", dep, behaviour))
 					theseDeps.Add(dep)
 					found = true
@@ -374,7 +374,7 @@ func (erlangApp *ErlangApp) testBeamFilesRules(args language.GenerateArgs, erlPa
 				}
 			}
 			if !found {
-				if dep, found := erlangConfig.BehaviourMappings[behaviour]; found {
+				if dep, found := erlangConfig.ModuleMappings[behaviour]; found {
 					Log(args.Config, "            behaviour", behaviour, "->", fmt.Sprintf("%s:%s", dep, behaviour))
 					theseDeps.Add(dep)
 					found = true
@@ -618,7 +618,7 @@ func (erlangApp *ErlangApp) testDirBeamFilesRules(args language.GenerateArgs, er
 				}
 			}
 			if !found {
-				if dep, found := erlangConfig.BehaviourMappings[behaviour]; found {
+				if dep, found := erlangConfig.ModuleMappings[behaviour]; found {
 					Log(args.Config, "            behaviour", behaviour, "->", fmt.Sprintf("%s:%s", dep, behaviour))
 					theseDeps.Add(dep)
 					found = true

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -508,7 +508,7 @@ func (erlang *erlangLang) GenerateRules(args language.GenerateArgs) language.Gen
 
 	allSrcsRules := erlangApp.allSrcsRules()
 
-	testDirBeamFilesRules := erlangApp.testDirBeamFilesRules(args, erlParser)
+	testDirBeamFilesRules := erlangApp.TestDirBeamFilesRules(args, erlParser)
 
 	if erlangConfig.GenerateBeamFilesMacro {
 		Log(args.Config, "    Adding/updating app.bzl")
@@ -622,7 +622,7 @@ func (erlang *erlangLang) GenerateRules(args language.GenerateArgs) language.Gen
 			eunitRule := erlangApp.eunitRule()
 			maybeAppendRule(erlangConfig, eunitRule, &result)
 
-			ctSuiteRules := erlangApp.ctSuiteRules(testDirBeamFilesRules)
+			ctSuiteRules := erlangApp.CtSuiteRules(testDirBeamFilesRules)
 			for _, r := range ctSuiteRules {
 				maybeAppendRule(erlangConfig, r, &result)
 			}

--- a/gazelle/util.go
+++ b/gazelle/util.go
@@ -48,6 +48,16 @@ func MapCat[T, R any](f func(T) []R, s []T) []R {
 	return result
 }
 
+func Keys[K comparable, V any](m map[K]V) []K {
+	r := make([]K, len(m))
+	i := 0
+	for k := range m {
+		r[i] = k
+		i++
+	}
+	return r
+}
+
 func Log(c *config.Config, a ...interface{}) (n int, err error) {
 	rootConfig := c.Exts[languageName].(ErlangConfigs)[""]
 	if rootConfig.Verbose {

--- a/test/erl_attrs_to_json/BUILD.bazel
+++ b/test/erl_attrs_to_json/BUILD.bazel
@@ -101,6 +101,7 @@ ct_suite(
     size = "small",
     data = [
         "test/basic.erl",
+        "test/test.erl",
     ],
     deps = [
         "@thoas//:erlang_app",

--- a/test/erl_attrs_to_json/test/basic.erl
+++ b/test/erl_attrs_to_json/test/basic.erl
@@ -15,4 +15,5 @@ myfunc() ->
 
 main(_) ->
     myfunc(),
+    _ = some_other_lib:bar(2),
     other_lib:foo(1).

--- a/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
+++ b/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
@@ -38,7 +38,8 @@ basic(_) ->
          parse_transform => [my_pt],
          call => #{
                    io => [format],
-                   other_lib => [foo]
+                   other_lib => [foo],
+                   some_other_lib => [bar]
                   }
         },
        erl_attrs_to_json:parse(fixture_path("test/basic.erl"), [])),
@@ -50,7 +51,8 @@ basic(_) ->
          parse_transform => [my_pt],
          call => #{
                    io => [format],
-                   other_lib => [foo]
+                   other_lib => [foo],
+                   some_other_lib => [bar]
                   }
         },
        erl_attrs_to_json:parse(fixture_path("test/basic.erl"), ['TEST'])).

--- a/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
+++ b/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
@@ -7,7 +7,8 @@
 
 all() -> [
           parse_command,
-          basic
+          basic,
+          test_src
          ].
 
 parse_command(_) ->
@@ -53,6 +54,17 @@ basic(_) ->
                   }
         },
        erl_attrs_to_json:parse(fixture_path("test/basic.erl"), ['TEST'])).
+
+test_src(_) ->
+   ?assertMatch(
+      #{
+        include_lib := ["proper/include/proper.hrl"],
+        parse_transform := [eunit_autoexport],
+        call := #{
+         proper := [counterexample]
+        }
+       },
+      erl_attrs_to_json:parse(fixture_path("test/test.erl"), ['TEST'])).
 
 fixture_path(File) ->
     filename:join([os:getenv("TEST_SRCDIR"),

--- a/test/erl_attrs_to_json/test/test.erl
+++ b/test/erl_attrs_to_json/test/test.erl
@@ -1,0 +1,92 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2017-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+-module(test).
+-compile(export_all).
+
+-include("src/ra.hrl").
+-include_lib("proper/include/proper.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+% just here to silence unused warning
+-export_type([op/0]).
+
+all() ->
+    [
+     non_assoc
+    ].
+
+groups() ->
+    [ {tests, [], all()} ].
+
+-type op() :: {add, 1..100} | {subtract, 1..100} | {divide, 2..10} | {mult, 1..10}.
+
+init_per_suite(Config) ->
+    {ok, _} = ra:start_in(?config(priv_dir, Config)),
+    Config.
+
+init_per_testcase(non_assoc, Config) ->
+    {ok, Cluster, _} = ra:start_cluster(default, non_assoc,
+                                        {simple, fun non_assoc_apply/2, 0},
+                                        [{n1, node()},
+                                         {n2, node()},
+                                         {n3, node()}]
+                                        ),
+    [{ra_cluster, Cluster} | Config].
+
+end_per_testcase(_, Config) ->
+    terminate_cluster(?config(ra_cluster, Config)),
+    Config.
+
+end_per_suite(Config) ->
+    application:stop(ra),
+    Config.
+
+%% this test mixes associative with non-associative operations to tests that
+%% all nodes apply operations in the same order
+non_assoc_prop([A, B, C], {Ops, Initial}) ->
+    ct:pal("non_assoc_prop Ops: ~p Initial: ~p", [Ops, Initial]),
+    Expected = lists:foldl(fun non_assoc_apply/2, Initial, Ops),
+    % set cluster to
+    {ok, _, Leader} = ra:process_command(A, {set, Initial}),
+    [ra:process_command(Leader, Op) || Op <- Ops],
+    {ok, _, Leader} = ra:consistent_query(A, fun(_) -> ok end),
+    timer:sleep(100),
+    {ok, {_, ARes}, _} = ra:local_query(A, fun id/1),
+    {ok, {_, BRes}, _} = ra:local_query(B, fun id/1),
+    {ok, {_, CRes}, _} = ra:local_query(C, fun id/1),
+    % ct:pal("Result ~p ~p ~p Expected ~p Initial ~p",
+    %        [ARes, BRes, CRes, Expected, Initial]),
+    % assert all nodes have the same final state
+    Expected == ARes andalso Expected == BRes andalso Expected == CRes.
+
+non_assoc(Config) ->
+    run_proper(
+      fun () ->
+              Cluster = ?config(ra_cluster, Config),
+              ?FORALL(N, {list(op()), integer(1, 1000)},
+                      non_assoc_prop(Cluster, N))
+      end, [], 25).
+
+id(X) -> X.
+
+non_assoc_apply({add, N}, State) -> State + N;
+non_assoc_apply({subtract, N}, State) -> State - N;
+non_assoc_apply({divide, N}, State) -> State / N;
+non_assoc_apply({mult, N}, State) -> State * N;
+non_assoc_apply({set, N}, _) -> N.
+
+terminate_cluster(Nodes) ->
+    [gen_statem:stop(P, normal, 2000) || {P, _} <- Nodes].
+
+run_proper(Fun, Args, NumTests) ->
+    ?assertEqual(
+       true,
+       proper:counterexample(erlang:apply(Fun, Args),
+			     [{numtests, NumTests},
+			      {on_output, fun(".", _) -> ok; % don't print the '.'s on new lines
+					     (F, A) -> ct:pal(?LOW_IMPORTANCE, F, A) end}])).

--- a/test/gazelle/BUILD.bazel
+++ b/test/gazelle/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     deps = [
         "@bazel_gazelle//config:go_default_library",
         "@bazel_gazelle//language:go_default_library",
+        "@bazel_gazelle//rule:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_onsi_ginkgo_v2//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",

--- a/test/gazelle/erlang_test.go
+++ b/test/gazelle/erlang_test.go
@@ -3,6 +3,7 @@ package erlang_test
 import (
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
 	"github.com/bazelbuild/buildtools/build"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -160,6 +161,60 @@ var _ = Describe("an ErlangApp", func() {
 
 			Expect(app.Deps.Values(strings.Compare)).To(
 				ContainElements("fuzz_app"))
+		})
+	})
+
+	Describe("Tests Rules", func() {
+		var fakeParser erlang.ErlParser
+		var testDirRules []*rule.Rule
+
+		BeforeEach(func() {
+			app.AddFile("src/foo.erl")
+			app.AddFile("test/foo_SUITE.erl")
+			app.AddFile("test/foo_helper.erl")
+
+			fakeParser = fakeErlParser(map[string]*erlang.ErlAttrs{
+				"src/foo.erl": &erlang.ErlAttrs{},
+				"test/foo_SUITE.erl": &erlang.ErlAttrs{
+					ParseTransform: []string{"foo"},
+					Call: map[string][]string{
+						"foo_helper": []string{"make_test_thing"},
+						"fuzz":       []string{"create"},
+					},
+				},
+				"test/foo_helper.erl": &erlang.ErlAttrs{},
+			})
+
+			erlangConfigs := args.Config.Exts["erlang"].(erlang.ErlangConfigs)
+			erlangConfig := erlangConfigs[args.Rel]
+			erlangConfig.ModuleMappings["fuzz"] = "fuzz_app"
+
+			testDirRules = app.TestDirBeamFilesRules(args, fakeParser)
+		})
+
+		Describe("TestDirBeamFilesRules", func() {
+			It("Adds runtime deps to the suite", func() {
+				Expect(testDirRules).To(HaveLen(2))
+
+				Expect(testDirRules[0].Name()).To(Equal("foo_SUITE_beam_files"))
+				Expect(testDirRules[0].AttrStrings("beam")).To(
+					ContainElements("ebin/foo.beam"))
+
+				Expect(testDirRules[1].Name()).To(Equal("test_foo_helper_beam"))
+			})
+		})
+
+		Describe("CtSuiteRules", func() {
+			It("Adds runtime deps to the suite", func() {
+				rules := app.CtSuiteRules(testDirRules)
+				Expect(rules).To(HaveLen(1))
+
+				Expect(rules[0].Name()).To(Equal("foo_SUITE"))
+				Expect(rules[0].AttrStrings("compiled_suites")).To(
+					ContainElements(":foo_SUITE_beam_files", "test/foo_helper.beam"))
+				Expect(rules[0].AttrStrings("deps")).To(
+					ContainElements(":test_erlang_app", "fuzz_app"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
Rename the directive, since it now affects parse transform and runtime call resolution

Also improve analysis for runtime deps