### PR TITLE
Generate more compact eunit rules with gazelle

### DIFF
--- a/eunit2.bzl
+++ b/eunit2.bzl
@@ -1,6 +1,5 @@
 load("//private:eunit.bzl", "eunit_test")
 
-# maybe just call this eunit_test, and rename this file?
 def eunit(
         name = "eunit",
         **kwargs):

--- a/gazelle/erlang_app.go
+++ b/gazelle/erlang_app.go
@@ -703,7 +703,7 @@ func (erlangApp *ErlangApp) dialyzeRule() *rule.Rule {
 	return r
 }
 
-func (erlangApp *ErlangApp) eunitRule() *rule.Rule {
+func (erlangApp *ErlangApp) EunitRule() *rule.Rule {
 	// eunit_mods is the list of source modules, plus any test module which is
 	// not among the source modules with a "_tests" suffix appended
 	modMap := make(map[string]string)
@@ -736,9 +736,10 @@ func (erlangApp *ErlangApp) eunitRule() *rule.Rule {
 	}
 
 	eunit := rule.NewRule(eunitKind, "eunit")
-	eunit.SetAttr("compiled_suites", compiled_suites.Values(strings.Compare))
-	eunit.SetAttr("eunit_mods", eunit_mods.Values(strings.Compare))
-	eunit.SetAttr("deps", []string{":test_erlang_app"})
+	if !compiled_suites.IsEmpty() {
+		eunit.SetAttr("compiled_suites", compiled_suites.Values(strings.Compare))
+	}
+	eunit.SetAttr("target", ":test_erlang_app")
 
 	return eunit
 }

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -619,7 +619,7 @@ func (erlang *erlangLang) GenerateRules(args language.GenerateArgs) language.Gen
 		maybeAppendRule(erlangConfig, dialyzeRule, &result)
 
 		if erlangApp.hasTestSuites() {
-			eunitRule := erlangApp.eunitRule()
+			eunitRule := erlangApp.EunitRule()
 			maybeAppendRule(erlangConfig, eunitRule, &result)
 
 			ctSuiteRules := erlangApp.CtSuiteRules(testDirBeamFilesRules)

--- a/gazelle/kinds.go
+++ b/gazelle/kinds.go
@@ -157,13 +157,13 @@ func (l *erlangLang) Kinds() map[string]rule.KindInfo {
 			MatchAny: true,
 			NonEmptyAttrs: map[string]bool{
 				"compiled_suites": true,
-				"eunit_mods":      true,
+				"target":          true,
 				"visibility":      true,
 			},
 			SubstituteAttrs: map[string]bool{},
 			MergeableAttrs: map[string]bool{
 				"compiled_suites": true,
-				"eunit_mods":      true,
+				"target":          true,
 			},
 			ResolveAttrs: map[string]bool{
 				"deps": true,

--- a/test/gazelle/erlang_test.go
+++ b/test/gazelle/erlang_test.go
@@ -170,8 +170,10 @@ var _ = Describe("an ErlangApp", func() {
 
 		BeforeEach(func() {
 			app.AddFile("src/foo.erl")
+			app.AddFile("src/bar.erl")
 			app.AddFile("test/foo_SUITE.erl")
 			app.AddFile("test/foo_helper.erl")
+			app.AddFile("test/bar_tests.erl")
 
 			fakeParser = fakeErlParser(map[string]*erlang.ErlAttrs{
 				"src/foo.erl": &erlang.ErlAttrs{},
@@ -194,13 +196,26 @@ var _ = Describe("an ErlangApp", func() {
 
 		Describe("TestDirBeamFilesRules", func() {
 			It("Adds runtime deps to the suite", func() {
-				Expect(testDirRules).To(HaveLen(2))
+				Expect(testDirRules).To(HaveLen(3))
 
-				Expect(testDirRules[0].Name()).To(Equal("foo_SUITE_beam_files"))
-				Expect(testDirRules[0].AttrStrings("beam")).To(
+				Expect(testDirRules[0].Name()).To(Equal("test_bar_tests_beam"))
+
+				Expect(testDirRules[1].Name()).To(Equal("foo_SUITE_beam_files"))
+				Expect(testDirRules[1].AttrStrings("beam")).To(
 					ContainElements("ebin/foo.beam"))
 
-				Expect(testDirRules[1].Name()).To(Equal("test_foo_helper_beam"))
+				Expect(testDirRules[2].Name()).To(Equal("test_foo_helper_beam"))
+			})
+		})
+
+		Describe("EunitRule", func() {
+			It("Adds runtime deps to the suite", func() {
+				r := app.EunitRule()
+
+				Expect(r.Name()).To(Equal("eunit"))
+				Expect(r.AttrStrings("compiled_suites")).To(
+					ContainElements(":test_foo_helper_beam"))
+				Expect(r.AttrString("target")).To(Equal(":test_erlang_app"))
 			})
 		})
 

--- a/test/gazelle/testdata/basic_rebar/BUILD.out
+++ b/test/gazelle/testdata/basic_rebar/BUILD.out
@@ -255,15 +255,7 @@ eunit(
         ":test_seshat_counters_server_test_beam",
         ":test_seshat_test_beam",
     ],
-    eunit_mods = [
-        "seshat",
-        "seshat_app",
-        "seshat_counters_server",
-        "seshat_counters_server_test",
-        "seshat_sup",
-        "seshat_test",
-    ],
-    deps = [":test_erlang_app"],
+    target = ":test_erlang_app",
 )
 
 assert_suites2()

--- a/test/gazelle/testdata/basic_rebar_gen_macro/BUILD.out
+++ b/test/gazelle/testdata/basic_rebar_gen_macro/BUILD.out
@@ -110,15 +110,7 @@ eunit(
         ":test_seshat_counters_server_test_beam",
         ":test_seshat_test_beam",
     ],
-    eunit_mods = [
-        "seshat",
-        "seshat_app",
-        "seshat_counters_server",
-        "seshat_counters_server_test",
-        "seshat_sup",
-        "seshat_test",
-    ],
-    deps = [":test_erlang_app"],
+    target = ":test_erlang_app",
 )
 
 assert_suites2()

--- a/test/gazelle/testdata/rebar_with_ct_suites/BUILD.out
+++ b/test/gazelle/testdata/rebar_with_ct_suites/BUILD.out
@@ -91,25 +91,7 @@ dialyze(
 
 eunit(
     name = "eunit",
-    compiled_suites = [],
-    eunit_mods = [
-        "osiris",
-        "osiris_app",
-        "osiris_bench",
-        "osiris_counters",
-        "osiris_log",
-        "osiris_log_shared",
-        "osiris_replica",
-        "osiris_replica_reader",
-        "osiris_replica_reader_sup",
-        "osiris_retention",
-        "osiris_server_sup",
-        "osiris_sup",
-        "osiris_tracking",
-        "osiris_util",
-        "osiris_writer",
-    ],
-    deps = [":test_erlang_app"],
+    target = ":test_erlang_app",
 )
 
 ct_test(


### PR DESCRIPTION
Add a new `target` attribute to the `eunit` rule that can be used in place of the `eunit_mods` attribute. This results in much less verbose `eunit` rules and more compact and maintainable BUILD files