### PR TITLE
Gazelle: compact erlang_bytecode rules option

### DIFF
--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "kinds.go",
         "language.go",
         "moduleindex.go",
-        "mutable_set.go",
         "rebar_config_parser.go",
         "resolve.go",
         "update.go",
@@ -30,6 +29,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//gazelle/fetch",
+        "//gazelle/mutable_set",
+        "//gazelle/slices",
         "@bazel_gazelle//config:go_default_library",
         "@bazel_gazelle//label:go_default_library",
         "@bazel_gazelle//language:go_default_library",

--- a/gazelle/configure.go
+++ b/gazelle/configure.go
@@ -113,7 +113,7 @@ func (erlang *Configurer) defaultErlangConfig(rel string) *ErlangConfig {
 		ExcludeWhenRuleOfKindExists:     mutable_set.New[string](),
 		IgnoredDeps:                     defaultIgnoredDeps,
 		GenerateBeamFilesMacro:          false,
-		GenerateFewerBytecodeRules:      false,
+		GenerateFewerBytecodeRules:      erlang.compact,
 		GenerateTestBeamUnconditionally: false,
 		GenerateSkipRules:               mutable_set.New[string](),
 		AppName:                         erlang.appName,
@@ -163,6 +163,7 @@ type Configurer struct {
 	appName       string
 	appVersion    string
 	noTests       bool
+	compact       bool
 	appsDir       string
 	buildFilesDir string
 }
@@ -173,6 +174,7 @@ func (erlang *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.
 		fs.StringVar(&erlang.appName, "app_name", "", "sets the application name, overriding inferred values")
 		fs.StringVar(&erlang.appVersion, "app_version", "", "sets the application version, overriding inferred values")
 		fs.BoolVar(&erlang.noTests, "no_tests", false, "when true, generates no rules associated with testing")
+		fs.BoolVar(&erlang.compact, "compact", false, "when true, generates fewer rules")
 		fs.StringVar(&erlang.appsDir, "default_apps_dir", "apps", "directory containing embedded applications in an umbrella project")
 	}
 	if cmd == "update-repos" {

--- a/gazelle/erl_attrs_to_json.sh
+++ b/gazelle/erl_attrs_to_json.sh
@@ -136,13 +136,16 @@ record_expression(E, {'case', _, Arg, Expressions}) ->
     lists:foreach(
       fun (Expression) -> record_expression(E, Expression) end,
       Expressions);
-record_expression(E, {'try', _, Expressions, _, Clauses, []}) ->
+record_expression(E, {'try', _, Expressions, _, Clauses, Afters}) ->
     lists:foreach(
       fun (Expression) -> record_expression(E, Expression) end,
       Expressions),
     lists:foreach(
       fun (Clause) -> record_expression(E, Clause) end,
-      Clauses);
+      Clauses),
+    lists:foreach(
+      fun (After) -> record_expression(E, After) end,
+      Afters);
 record_expression(E, {match, _, Lhs, Rhs}) ->
     record_expression(E, Lhs),
     record_expression(E, Rhs);

--- a/gazelle/erl_parser_impl.go
+++ b/gazelle/erl_parser_impl.go
@@ -135,7 +135,7 @@ func (p *erlParserImpl) parseHrl(hrlFile string, erlangApp *ErlangApp, macros Er
 func (p *erlParserImpl) DeepParseErl(erlFile string, erlangApp *ErlangApp, macros ErlParserMacros) (*ErlAttrs, error) {
 	erlFilePath := filepath.Join(erlangApp.RepoRoot, erlangApp.Rel, erlFile)
 	if _, err := os.Stat(erlFilePath); errors.Is(err, os.ErrNotExist) {
-		return &ErlAttrs{}, nil
+		return nil, err
 	}
 
 	rootAttrs, err := p.parseErl(erlFilePath, macros)

--- a/gazelle/erlang_app.go
+++ b/gazelle/erlang_app.go
@@ -347,6 +347,7 @@ func (erlangApp *ErlangApp) BeamFilesRules(args language.GenerateArgs, erlParser
 			xformsRule.SetAttr("outs", mutable_set.Map(transforms, beamFile).Values(strings.Compare))
 			xformsDeps := erlangApp.dependencies(args.Config, erlangConfig, moduleindex, erlAttrsBySrc, transforms.ValuesUnordered()...)
 			xformsRule.SetAttr("deps", xformsDeps.Deps.Values(strings.Compare))
+			erlangApp.Deps.Union(xformsDeps.Deps)
 			erlangApp.Deps.Union(xformsDeps.RuntimeDeps)
 			beamFilesRules = append(beamFilesRules, xformsRule)
 			beamFilesGroupRules = append(beamFilesGroupRules, ":"+xformsRule.Name())
@@ -364,6 +365,7 @@ func (erlangApp *ErlangApp) BeamFilesRules(args language.GenerateArgs, erlParser
 			}
 			behavioursDeps := erlangApp.dependencies(args.Config, erlangConfig, moduleindex, erlAttrsBySrc, behaviours.ValuesUnordered()...)
 			behavioursRule.SetAttr("deps", behavioursDeps.Deps.Values(strings.Compare))
+			erlangApp.Deps.Union(behavioursDeps.Deps)
 			erlangApp.Deps.Union(behavioursDeps.RuntimeDeps)
 			beamFilesRules = append(beamFilesRules, behavioursRule)
 			beamFilesGroupRules = append(beamFilesGroupRules, ":"+behavioursRule.Name())
@@ -380,6 +382,7 @@ func (erlangApp *ErlangApp) BeamFilesRules(args language.GenerateArgs, erlParser
 			othersRule.SetAttr("beam", beamFilesGroupRules)
 			othersDeps := erlangApp.dependencies(args.Config, erlangConfig, moduleindex, erlAttrsBySrc, others.ValuesUnordered()...)
 			othersRule.SetAttr("deps", othersDeps.Deps.Values(strings.Compare))
+			erlangApp.Deps.Union(othersDeps.Deps)
 			erlangApp.Deps.Union(othersDeps.RuntimeDeps)
 			beamFilesRules = append(beamFilesRules, othersRule)
 			beamFilesGroupRules = append(beamFilesGroupRules, ":"+othersRule.Name())
@@ -393,7 +396,8 @@ func (erlangApp *ErlangApp) BeamFilesRules(args language.GenerateArgs, erlParser
 		for _, src := range erlangApp.Srcs.Values(strings.Compare) {
 			deps := erlangApp.dependencies(args.Config, erlangConfig, moduleindex, erlAttrsBySrc, src)
 
-			erlangApp.Deps.Add(deps.RuntimeDeps.ValuesUnordered()...)
+			erlangApp.Deps.Union(deps.Deps)
+			erlangApp.Deps.Union(deps.RuntimeDeps)
 
 			out := beamFile(src)
 			outs.Add(out)
@@ -473,6 +477,7 @@ func (erlangApp *ErlangApp) testBeamFilesRules(args language.GenerateArgs, erlPa
 			xformsRule.SetAttr("outs", mutable_set.Map(transforms, testBeamFile).Values(strings.Compare))
 			xformsDeps := erlangApp.dependencies(args.Config, erlangConfig, moduleindex, erlAttrsBySrc, transforms.ValuesUnordered()...)
 			xformsRule.SetAttr("deps", xformsDeps.Deps.Values(strings.Compare))
+			erlangApp.TestDeps.Union(xformsDeps.Deps)
 			erlangApp.TestDeps.Union(xformsDeps.RuntimeDeps)
 			testBeamFilesRules = append(testBeamFilesRules, xformsRule)
 			beamFilesGroupRules = append(beamFilesGroupRules, ":"+xformsRule.Name())
@@ -491,6 +496,7 @@ func (erlangApp *ErlangApp) testBeamFilesRules(args language.GenerateArgs, erlPa
 			}
 			behavioursDeps := erlangApp.dependencies(args.Config, erlangConfig, moduleindex, erlAttrsBySrc, behaviours.ValuesUnordered()...)
 			behavioursRule.SetAttr("deps", behavioursDeps.Deps.Values(strings.Compare))
+			erlangApp.TestDeps.Union(behavioursDeps.Deps)
 			erlangApp.TestDeps.Union(behavioursDeps.RuntimeDeps)
 			testBeamFilesRules = append(testBeamFilesRules, behavioursRule)
 			beamFilesGroupRules = append(beamFilesGroupRules, ":"+behavioursRule.Name())
@@ -508,6 +514,7 @@ func (erlangApp *ErlangApp) testBeamFilesRules(args language.GenerateArgs, erlPa
 			othersRule.SetAttr("beam", beamFilesGroupRules)
 			othersDeps := erlangApp.dependencies(args.Config, erlangConfig, moduleindex, erlAttrsBySrc, others.ValuesUnordered()...)
 			othersRule.SetAttr("deps", othersDeps.Deps.Values(strings.Compare))
+			erlangApp.TestDeps.Union(othersDeps.Deps)
 			erlangApp.TestDeps.Union(othersDeps.RuntimeDeps)
 			testBeamFilesRules = append(testBeamFilesRules, othersRule)
 			beamFilesGroupRules = append(beamFilesGroupRules, ":"+othersRule.Name())
@@ -522,7 +529,8 @@ func (erlangApp *ErlangApp) testBeamFilesRules(args language.GenerateArgs, erlPa
 		for _, src := range erlangApp.Srcs.Values(strings.Compare) {
 			deps := erlangApp.dependencies(args.Config, erlangConfig, moduleindex, erlAttrsBySrc, src)
 
-			erlangApp.TestDeps.Add(deps.RuntimeDeps.ValuesUnordered()...)
+			erlangApp.Deps.Union(deps.Deps)
+			erlangApp.Deps.Union(deps.RuntimeDeps)
 
 			test_out := testBeamFile(src)
 			testOuts.Add(test_out)
@@ -595,7 +603,7 @@ func (erlangApp *ErlangApp) allSrcsRules() []*rule.Rule {
 	return rules
 }
 
-func (erlangApp *ErlangApp) erlangAppRule(explicitFiles bool) *rule.Rule {
+func (erlangApp *ErlangApp) ErlangAppRule(explicitFiles bool) *rule.Rule {
 	r := rule.NewRule(erlangAppKind, "erlang_app")
 	r.SetAttr("app_name", erlangApp.Name)
 	if erlangApp.Version != "" {

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -597,7 +597,7 @@ func (erlang *erlangLang) GenerateRules(args language.GenerateArgs) language.Gen
 	}
 
 	explicitFiles := erlangApp.RepoRoot != args.Config.RepoRoot
-	erlang_app := erlangApp.ErlangAppRule(explicitFiles)
+	erlang_app := erlangApp.ErlangAppRule(args, explicitFiles)
 	maybeAppendRule(erlangConfig, erlang_app, &result)
 
 	alias := rule.NewRule("alias", erlangApp.Name)
@@ -607,7 +607,7 @@ func (erlang *erlangLang) GenerateRules(args language.GenerateArgs) language.Gen
 
 	if !erlangConfig.NoTests {
 		if erlangApp.hasTestSuites() || erlangConfig.GenerateTestBeamUnconditionally {
-			test_erlang_app := erlangApp.testErlangAppRule(explicitFiles)
+			test_erlang_app := erlangApp.testErlangAppRule(args, explicitFiles)
 			maybeAppendRule(erlangConfig, test_erlang_app, &result)
 		}
 

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -597,7 +597,7 @@ func (erlang *erlangLang) GenerateRules(args language.GenerateArgs) language.Gen
 	}
 
 	explicitFiles := erlangApp.RepoRoot != args.Config.RepoRoot
-	erlang_app := erlangApp.erlangAppRule(explicitFiles)
+	erlang_app := erlangApp.ErlangAppRule(explicitFiles)
 	maybeAppendRule(erlangConfig, erlang_app, &result)
 
 	alias := rule.NewRule("alias", erlangApp.Name)

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -13,6 +13,8 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/rule"
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/rabbitmq/rules_erlang/gazelle/fetch"
+	"github.com/rabbitmq/rules_erlang/gazelle/mutable_set"
+	"github.com/rabbitmq/rules_erlang/gazelle/slices"
 )
 
 const (
@@ -56,7 +58,7 @@ func filterOutDirectories(files []string) []string {
 	}
 	filtered := []string{}
 	for _, f := range files {
-		if !Contains(dirs, f) {
+		if !slices.Contains(dirs, f) {
 			filtered = append(filtered, f)
 		}
 	}
@@ -64,16 +66,16 @@ func filterOutDirectories(files []string) []string {
 }
 
 func isHexPmTar(regularFiles []string) bool {
-	return ContainsAll(regularFiles, hexPmFiles)
+	return slices.ContainsAll(regularFiles, hexPmFiles)
 }
 
 func isRebar(regularFiles []string) bool {
-	return Contains(regularFiles, rebarConfigFilename)
+	return slices.Contains(regularFiles, rebarConfigFilename)
 }
 
 func isProbablyBareErlang(args language.GenerateArgs) bool {
 	// if there is a src dir with .erl files in it
-	if Contains(args.Subdirs, "src") {
+	if slices.Contains(args.Subdirs, "src") {
 		hasErlFiles := false
 		err := filepath.WalkDir(filepath.Join(args.Config.RepoRoot, args.Rel, "src"),
 			func(path string, info os.DirEntry, err error) error {
@@ -142,7 +144,7 @@ func importHexPmTar(args language.GenerateArgs, result *language.GenerateResult,
 		return err
 	}
 
-	if Contains(hexMetadata.BuildTools, "rebar3") {
+	if slices.Contains(hexMetadata.BuildTools, "rebar3") {
 		err = importRebar(args, erlangApp)
 		if err != nil {
 			return err
@@ -175,7 +177,7 @@ func importRebar(args language.GenerateArgs, erlangApp *ErlangApp) error {
 				if err != nil {
 					return err
 				}
-				if info.IsDir() && Contains(ignoredDirs, filepath.Base(path)) {
+				if info.IsDir() && slices.Contains(ignoredDirs, filepath.Base(path)) {
 					return filepath.SkipDir
 				}
 				rel, err := filepath.Rel(rebarAppPath, path)
@@ -206,7 +208,7 @@ func importBareErlang(args language.GenerateArgs, erlangApp *ErlangApp) error {
 				return err
 			}
 			if info.IsDir() {
-				if Contains(ignoredDirs, filepath.Base(path)) {
+				if slices.Contains(ignoredDirs, filepath.Base(path)) {
 					return filepath.SkipDir
 				} else {
 					return nil
@@ -234,9 +236,9 @@ func importBareErlang(args language.GenerateArgs, erlangApp *ErlangApp) error {
 }
 
 func mergeAttr(src, dst *rule.Rule, attr string) {
-	srcVals := NewMutableSet(src.AttrStrings(attr)...)
-	dstVals := NewMutableSet(dst.AttrStrings(attr)...)
-	mergedVals := Union(srcVals, dstVals)
+	srcVals := mutable_set.New(src.AttrStrings(attr)...)
+	dstVals := mutable_set.New(dst.AttrStrings(attr)...)
+	mergedVals := mutable_set.Union(srcVals, dstVals)
 	if mergedVals.IsEmpty() {
 		dst.DelAttr(attr)
 	} else {
@@ -304,7 +306,7 @@ func ensureLoad(name, symbol string, index int, f *rule.File) {
 	for _, load := range f.Loads {
 		if load.Name() == name {
 			needsLoad = false
-			if !Contains(load.Symbols(), symbol) {
+			if !slices.Contains(load.Symbols(), symbol) {
 				load.Add(symbol)
 			}
 		}
@@ -440,7 +442,7 @@ func (erlang *erlangLang) GenerateRules(args language.GenerateArgs) language.Gen
 		erlangApp.Name = strings.TrimSuffix(filepath.Base(erlangApp.Ebin.Any()), ".app")
 		props := (*dotApp)[erlangApp.Name]
 		for _, app := range props.Applications {
-			if !Contains([]string{"kernel", "stdlib"}, app) {
+			if !slices.Contains([]string{"kernel", "stdlib"}, app) {
 				erlangApp.ExtraApps.Add(app)
 			}
 		}
@@ -455,7 +457,7 @@ func (erlang *erlangLang) GenerateRules(args language.GenerateArgs) language.Gen
 		erlangApp.Name = strings.TrimSuffix(filepath.Base(erlangApp.AppSrc.Any()), ".app.src")
 		props := (*dotApp)[erlangApp.Name]
 		for _, app := range props.Applications {
-			if !Contains([]string{"kernel", "stdlib"}, app) {
+			if !slices.Contains([]string{"kernel", "stdlib"}, app) {
 				erlangApp.ExtraApps.Add(app)
 			}
 		}

--- a/gazelle/moduleindex.go
+++ b/gazelle/moduleindex.go
@@ -6,14 +6,16 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type Moduleindex map[string][]string
+
 func MergeAppToModuleindex(moduleindexPath string, erlangApp *ErlangApp) error {
-	return MergeToModuleindex(moduleindexPath, map[string][]string{
+	return MergeToModuleindex(moduleindexPath, Moduleindex{
 		erlangApp.Name: erlangApp.modules(),
 	})
 }
 
-func MergeToModuleindex(moduleindexPath string, entries map[string][]string) error {
-	moduleindex := make(map[string][]string)
+func MergeToModuleindex(moduleindexPath string, entries Moduleindex) error {
+	moduleindex := make(Moduleindex)
 	moduleindexFile, err := os.OpenFile(moduleindexPath, os.O_RDWR|os.O_CREATE, 0755)
 	if err != nil {
 		return err
@@ -43,8 +45,8 @@ func MergeToModuleindex(moduleindexPath string, entries map[string][]string) err
 	return encoder.Encode(moduleindex)
 }
 
-func ReadModuleindex(file string) (map[string][]string, error) {
-	moduleindex := make(map[string][]string)
+func ReadModuleindex(file string) (Moduleindex, error) {
+	moduleindex := make(Moduleindex)
 	reader, err := os.Open(file)
 	if err != nil {
 		return nil, err
@@ -59,7 +61,7 @@ func ReadModuleindex(file string) (map[string][]string, error) {
 	return moduleindex, nil
 }
 
-func FindModule(moduleindex map[string][]string, module string) string {
+func FindModule(moduleindex Moduleindex, module string) string {
 	for app, modules := range moduleindex {
 		if Contains(modules, module) {
 			return app

--- a/gazelle/moduleindex.go
+++ b/gazelle/moduleindex.go
@@ -3,6 +3,7 @@ package erlang
 import (
 	"os"
 
+	"github.com/rabbitmq/rules_erlang/gazelle/slices"
 	"gopkg.in/yaml.v2"
 )
 
@@ -63,7 +64,7 @@ func ReadModuleindex(file string) (Moduleindex, error) {
 
 func FindModule(moduleindex Moduleindex, module string) string {
 	for app, modules := range moduleindex {
-		if Contains(modules, module) {
+		if slices.Contains(modules, module) {
 			return app
 		}
 	}

--- a/gazelle/mutable_set.go
+++ b/gazelle/mutable_set.go
@@ -68,12 +68,17 @@ func Copy[T comparable](set MutableSet[T]) MutableSet[T] {
 }
 
 func (s MutableSet[T]) Values(compare func(i T, j T) int) []T {
+	values := s.ValuesUnordered()
+	sort.SliceStable(values, func(i, j int) bool {
+		return compare(values[i], values[j]) == -1
+	})
+	return values
+}
+
+func (s MutableSet[T]) ValuesUnordered() []T {
 	var values []T
 	for item := range s {
 		values = append(values, item)
 	}
-	sort.SliceStable(values, func(i, j int) bool {
-		return compare(values[i], values[j]) == -1
-	})
 	return values
 }

--- a/gazelle/mutable_set/BUILD.bazel
+++ b/gazelle/mutable_set/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mutable_set",
+    srcs = [
+        "mutable_set.go",
+    ],
+    importpath = "github.com/rabbitmq/rules_erlang/gazelle/mutable_set",
+    visibility = ["//visibility:public"],
+)

--- a/gazelle/mutable_set/mutable_set.go
+++ b/gazelle/mutable_set/mutable_set.go
@@ -61,6 +61,16 @@ func (s MutableSet[T]) Subtract(other MutableSet[T]) {
 	}
 }
 
+func (s MutableSet[T]) Clone() MutableSet[T] {
+	r := make(MutableSet[T], len(s))
+	for item, present := range s {
+		if present {
+			r[item] = true
+		}
+	}
+	return r
+}
+
 func GroupBy[T, K comparable](s MutableSet[T], f func(v T) K) map[K][]T {
 	r := make(map[K][]T, len(s))
 	s.ForEach(func(v T) {

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -13,11 +13,12 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/repo"
 	"github.com/bazelbuild/bazel-gazelle/resolve"
 	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/rabbitmq/rules_erlang/gazelle/mutable_set"
 )
 
 const languageName = "erlang"
 
-var resolveableKinds = NewMutableSet(
+var resolveableKinds = mutable_set.New(
 	erlangBytecodeKind,
 	erlangAppKind,
 	testErlangAppKind,

--- a/gazelle/slices/BUILD.bazel
+++ b/gazelle/slices/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "slices",
+    srcs = [
+        "slices.go",
+    ],
+    importpath = "github.com/rabbitmq/rules_erlang/gazelle/slices",
+    visibility = ["//visibility:public"],
+)

--- a/gazelle/slices/slices.go
+++ b/gazelle/slices/slices.go
@@ -1,0 +1,35 @@
+package slices
+
+func Contains[T comparable](s []T, e T) bool {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
+}
+
+func ContainsAll[T comparable](s []T, elements []T) bool {
+	for _, element := range elements {
+		if !Contains(s, element) {
+			return false
+		}
+	}
+	return true
+}
+
+func Map[T, R any](f func(T) R, s []T) []R {
+	result := make([]R, len(s))
+	for i, elem := range s {
+		result[i] = f(elem)
+	}
+	return result
+}
+
+func MapCat[T, R any](f func(T) []R, s []T) []R {
+	var result []R
+	for _, elem := range s {
+		result = append(result, f(elem)...)
+	}
+	return result
+}

--- a/gazelle/update.go
+++ b/gazelle/update.go
@@ -121,6 +121,7 @@ func ruleForHexPackage(config *config.Config, name, pkg, version string) (*rule.
 
 	cmd.Args = append(cmd.Args, "--verbose")
 	cmd.Args = append(cmd.Args, "--no_tests")
+	cmd.Args = append(cmd.Args, "--compact")
 	if explicitName {
 		cmd.Args = append(cmd.Args, "--app_name", name)
 	}
@@ -278,6 +279,7 @@ func tryImportGithub(config *config.Config, imp string) (*rule.Rule, error) {
 
 	cmd.Args = append(cmd.Args, "--verbose")
 	cmd.Args = append(cmd.Args, "--no_tests")
+	cmd.Args = append(cmd.Args, "--compact")
 	if explicitName {
 		cmd.Args = append(cmd.Args, "--app_name", name)
 	}

--- a/gazelle/util.go
+++ b/gazelle/util.go
@@ -6,24 +6,6 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/config"
 )
 
-func Contains[T comparable](s []T, e T) bool {
-	for _, v := range s {
-		if v == e {
-			return true
-		}
-	}
-	return false
-}
-
-func ContainsAll[T comparable](s []T, elements []T) bool {
-	for _, element := range elements {
-		if !Contains(s, element) {
-			return false
-		}
-	}
-	return true
-}
-
 func CopyMap[K, V comparable](m map[K]V) map[K]V {
 	result := make(map[K]V)
 	for k, v := range m {
@@ -32,23 +14,7 @@ func CopyMap[K, V comparable](m map[K]V) map[K]V {
 	return result
 }
 
-func Map[T, R any](f func(T) R, s []T) []R {
-	result := make([]R, len(s))
-	for i, elem := range s {
-		result[i] = f(elem)
-	}
-	return result
-}
-
-func MapCat[T, R any](f func(T) []R, s []T) []R {
-	var result []R
-	for _, elem := range s {
-		result = append(result, f(elem)...)
-	}
-	return result
-}
-
-func Keys[K comparable, V any](m map[K]V) []K {
+func Keys[K comparable](m map[K]any) []K {
 	r := make([]K, len(m))
 	i := 0
 	for k := range m {

--- a/private/erlang_bytecode2.bzl
+++ b/private/erlang_bytecode2.bzl
@@ -16,6 +16,9 @@ ErlcOptsInfo = provider(
 )
 
 def _impl(ctx):
+    if len(ctx.attr.outs) == 0:
+        fail("attr outs must not be empty")
+
     outputs = [
         ctx.actions.declare_file(f.name)
         for f in ctx.attr.outs

--- a/private/eunit.bzl
+++ b/private/eunit.bzl
@@ -105,7 +105,7 @@ fi
 
 set -x
 "{erlang_home}"/bin/erl +A1 -noinput -boot no_dot_erlang \\
-    {pa_args} \\
+    {pa_args} {extra_args} \\
     -eval "case eunit:test({eunit_mods_term},{eunit_opts_term}) of ok -> ok; error -> halt(2) end, halt()"
 """.format(
             maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
@@ -113,6 +113,7 @@ set -x
             erl_libs_path = erl_libs_path if len(erl_libs_files) > 0 else "",
             package = package,
             pa_args = " ".join(pa_args),
+            extra_args = " ".join(ctx.attr.erl_extra_args),
             eunit_mods_term = _to_atom_list(eunit_mods),
             eunit_opts_term = eunit_opts_term,
             test_env = "\n".join(test_env_commands),
@@ -136,13 +137,14 @@ if NOT [{package}] == [] cd {package}
 
 echo on
 "{erlang_home}\\bin\\erl" +A1 -noinput -boot no_dot_erlang ^
-    {pa_args} ^
+    {pa_args} {extra_args} ^
     -eval "case eunit:test({eunit_mods_term},{eunit_opts_term}) of ok -> ok; error -> halt(2) end, halt()" || exit /b 1
 """.format(
             package = package,
             erlang_home = windows_path(erlang_home),
             erl_libs_path = erl_libs_path if len(erl_libs_files) > 0 else "",
             pa_args = " ".join(pa_args),
+            extra_args = " ".join(ctx.attr.erl_extra_args),
             eunit_mods_term = _to_atom_list(eunit_mods),
             eunit_opts_term = eunit_opts_term,
             test_env = "\n".join(test_env_commands),
@@ -179,6 +181,7 @@ eunit_test = rule(
         ),
         "eunit_mods": attr.string_list(),
         "target": attr.label(providers = [ErlangAppInfo]),
+        "erl_extra_args": attr.string_list(),
         "eunit_opts": attr.string_list(),
         "data": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [ErlangAppInfo]),

--- a/private/eunit.bzl
+++ b/private/eunit.bzl
@@ -72,6 +72,9 @@ def _impl(ctx):
     erl_libs_path = path_join(package, erl_libs_dir)
 
     pa_args = []
+    if ctx.attr.target != None:
+        for dir in package_relative_dirnames(package, ctx.attr.target[ErlangAppInfo].beam):
+            pa_args.extend(["-pa", dir])
     for dir in package_relative_dirnames(package, ctx.files.compiled_suites):
         pa_args.extend(["-pa", dir])
 

--- a/test/erl_attrs_to_json/test/basic.erl
+++ b/test/erl_attrs_to_json/test/basic.erl
@@ -14,6 +14,8 @@ myfunc(M) when is_map(M) ->
     try maps:merge(M, #{k2 => other_lib:encode(<<"string">>)})
     catch _:_ ->
         invalid
+    after
+        other_lib:finalize()
     end,
     io:format("Hello~n", []),
     {ok, some_other_lib:fizz()}.

--- a/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
+++ b/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
@@ -40,7 +40,7 @@ basic(_) ->
                    filename => [split],
                    io => [format],
                    maps => [merge],
-                   other_lib => [foo, encode],
+                   other_lib => [foo, finalize, encode],
                    some_other_lib => [bar, baz, fizz]
                   }
         },
@@ -55,7 +55,7 @@ basic(_) ->
                    filename => [split],
                    io => [format],
                    maps => [merge],
-                   other_lib => [foo, encode],
+                   other_lib => [foo, finalize, encode],
                    some_other_lib => [bar, baz, fizz]
                   }
         },

--- a/test/gazelle/BUILD.bazel
+++ b/test/gazelle/BUILD.bazel
@@ -39,6 +39,17 @@ go_test(
 )
 
 go_test(
+    name = "mutable_set_test",
+    srcs = ["mutable_set_test.go"],
+    tags = ["manual"],
+    deps = [
+        "@com_github_onsi_ginkgo_v2//:go_default_library",
+        "@com_github_onsi_gomega//:go_default_library",
+        "@rules_erlang//gazelle/mutable_set",
+    ],
+)
+
+go_test(
     name = "erlang_test",
     srcs = [
         "erlang_test.go",
@@ -62,6 +73,7 @@ test_suite(
     tests = [
         "erlang_test",
         "fetch_test",
+        "mutable_set_test",
     ],
 )
 

--- a/test/gazelle/erlang_test.go
+++ b/test/gazelle/erlang_test.go
@@ -115,7 +115,7 @@ var _ = Describe("an ErlangApp", func() {
 
 			Expect(rules[0].Name()).To(Equal("ebin_foo_beam"))
 			Expect(rules[0].AttrStrings("hdrs")).To(
-				ContainElements("src/foo.hrl"))
+				ConsistOf("src/foo.hrl"))
 		})
 
 		It("resolves parse_transforms", func() {
@@ -134,7 +134,7 @@ var _ = Describe("an ErlangApp", func() {
 
 			Expect(rules[1].Name()).To(Equal("ebin_foo_beam"))
 			Expect(rules[1].AttrStrings("beam")).To(
-				ContainElements("ebin/bar.beam"))
+				ConsistOf("ebin/bar.beam"))
 		})
 
 		It("honors erlang_module_source_lib directives", func() {
@@ -157,10 +157,10 @@ var _ = Describe("an ErlangApp", func() {
 
 			Expect(rules[0].Name()).To(Equal("ebin_foo_beam"))
 			Expect(rules[0].AttrStrings("deps")).To(
-				ContainElements("baz_app"))
+				ConsistOf("baz_app"))
 
 			Expect(app.Deps.Values(strings.Compare)).To(
-				ContainElements("fuzz_app"))
+				ConsistOf("baz_app", "fuzz_app"))
 		})
 	})
 
@@ -176,7 +176,6 @@ var _ = Describe("an ErlangApp", func() {
 			app.AddFile("test/bar_tests.erl")
 
 			fakeParser = fakeErlParser(map[string]*erlang.ErlAttrs{
-				"src/foo.erl": &erlang.ErlAttrs{},
 				"test/foo_SUITE.erl": &erlang.ErlAttrs{
 					ParseTransform: []string{"foo"},
 					Call: map[string][]string{
@@ -184,7 +183,6 @@ var _ = Describe("an ErlangApp", func() {
 						"fuzz":       []string{"create"},
 					},
 				},
-				"test/foo_helper.erl": &erlang.ErlAttrs{},
 			})
 
 			erlangConfigs := args.Config.Exts["erlang"].(erlang.ErlangConfigs)
@@ -202,7 +200,7 @@ var _ = Describe("an ErlangApp", func() {
 
 				Expect(testDirRules[1].Name()).To(Equal("foo_SUITE_beam_files"))
 				Expect(testDirRules[1].AttrStrings("beam")).To(
-					ContainElements("ebin/foo.beam"))
+					ConsistOf("ebin/foo.beam"))
 
 				Expect(testDirRules[2].Name()).To(Equal("test_foo_helper_beam"))
 			})
@@ -214,7 +212,7 @@ var _ = Describe("an ErlangApp", func() {
 
 				Expect(r.Name()).To(Equal("eunit"))
 				Expect(r.AttrStrings("compiled_suites")).To(
-					ContainElements(":test_foo_helper_beam"))
+					ConsistOf(":test_foo_helper_beam", ":test_bar_tests_beam"))
 				Expect(r.AttrString("target")).To(Equal(":test_erlang_app"))
 			})
 		})
@@ -226,9 +224,9 @@ var _ = Describe("an ErlangApp", func() {
 
 				Expect(rules[0].Name()).To(Equal("foo_SUITE"))
 				Expect(rules[0].AttrStrings("compiled_suites")).To(
-					ContainElements(":foo_SUITE_beam_files", "test/foo_helper.beam"))
+					ConsistOf(":foo_SUITE_beam_files", "test/foo_helper.beam"))
 				Expect(rules[0].AttrStrings("deps")).To(
-					ContainElements(":test_erlang_app", "fuzz_app"))
+					ConsistOf(":test_erlang_app", "fuzz_app"))
 			})
 		})
 	})
@@ -269,44 +267,44 @@ var _ = Describe("an ErlangApp", func() {
 			Expect(rules[0].AttrString("app_name")).To(Equal(app.Name))
 			Expect(rules[0].AttrString("erlc_opts")).To(Equal("//:erlc_opts"))
 			Expect(rules[0].AttrStrings("srcs")).To(
-				ContainElements("src/xform.erl"),
+				ConsistOf("src/xform.erl"),
 			)
 			Expect(rules[0].AttrStrings("outs")).To(
-				ContainElements("ebin/xform.beam"),
+				ConsistOf("ebin/xform.beam"),
 			)
 
 			Expect(rules[1].Name()).To(Equal("behaviours"))
 			Expect(rules[1].AttrString("app_name")).To(Equal(app.Name))
 			Expect(rules[1].AttrString("erlc_opts")).To(Equal("//:erlc_opts"))
 			Expect(rules[1].AttrStrings("srcs")).To(
-				ContainElements("src/bar.erl", "src/baz.erl"),
+				ConsistOf("src/bar.erl", "src/baz.erl"),
 			)
 			Expect(rules[1].AttrStrings("outs")).To(
-				ContainElements("ebin/bar.beam", "ebin/baz.beam"),
+				ConsistOf("ebin/bar.beam", "ebin/baz.beam"),
 			)
 			Expect(rules[1].AttrStrings("beam")).To(
-				ContainElements(":parse_transforms"),
+				ConsistOf(":parse_transforms"),
 			)
 
 			Expect(rules[2].Name()).To(Equal("other_beam"))
 			Expect(rules[2].AttrString("app_name")).To(Equal(app.Name))
 			Expect(rules[2].AttrString("erlc_opts")).To(Equal("//:erlc_opts"))
 			Expect(rules[2].AttrStrings("srcs")).To(
-				ContainElements("src/foo.erl"),
+				ConsistOf("src/foo.erl"),
 			)
 			Expect(rules[2].AttrStrings("outs")).To(
-				ContainElements("ebin/foo.beam"),
+				ConsistOf("ebin/foo.beam"),
 			)
 			Expect(rules[2].AttrStrings("beam")).To(
-				ContainElements(":parse_transforms", ":behaviours"),
+				ConsistOf(":parse_transforms", ":behaviours"),
 			)
 			Expect(rules[2].AttrStrings("deps")).To(
-				ContainElements("other"),
+				ConsistOf("other"),
 			)
 
 			Expect(rules[3].Name()).To(Equal("beam_files"))
 			Expect(rules[3].AttrStrings("srcs")).To(
-				ContainElements(
+				ConsistOf(
 					":"+rules[0].Name(),
 					":"+rules[1].Name(),
 					":"+rules[2].Name(),
@@ -316,11 +314,31 @@ var _ = Describe("an ErlangApp", func() {
 
 		It("Adds discoverd deps to the application", func() {
 			app.BeamFilesRules(args, fakeParser)
-			r := app.ErlangAppRule(true)
+			r := app.ErlangAppRule(args, true)
 
 			Expect(r.Name()).To(Equal("erlang_app"))
 			Expect(r.AttrStrings("deps")).To(
-				ContainElements("other", "fuzz_app"),
+				ConsistOf("other", "fuzz_app"),
+			)
+		})
+
+		It("Treats deps marked with the erlang_app_dep_exclude directive as a build dep only", func() {
+			erlangConfigs := args.Config.Exts["erlang"].(erlang.ErlangConfigs)
+			erlangConfig := erlangConfigs[args.Rel]
+			erlangConfig.ExcludedDeps.Add("other")
+
+			rules := app.BeamFilesRules(args, fakeParser)
+
+			Expect(rules[2].Name()).To(Equal("other_beam"))
+			Expect(rules[2].AttrStrings("deps")).To(
+				ConsistOf("other"),
+			)
+
+			r := app.ErlangAppRule(args, true)
+
+			Expect(r.Name()).To(Equal("erlang_app"))
+			Expect(r.AttrStrings("deps")).To(
+				ConsistOf("fuzz_app"),
 			)
 		})
 	})

--- a/test/gazelle/mutable_set_test.go
+++ b/test/gazelle/mutable_set_test.go
@@ -1,0 +1,37 @@
+package mutable_set_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rabbitmq/rules_erlang/gazelle/mutable_set"
+	"strings"
+	"testing"
+)
+
+func TestUpdate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MutableSet Suite")
+}
+
+var _ = Describe("MutableSet", func() {
+	Describe("Contains", func() {
+		It("creates a set", func() {
+			s := mutable_set.New("a")
+			Expect(s.Contains("a")).To(BeTrue())
+			Expect(s.Contains("b")).To(BeFalse())
+		})
+	})
+
+	Describe("Map", func() {
+		It("transforms the set's values", func() {
+			in := mutable_set.New("first", "second", "third")
+			out := mutable_set.Map(in, strings.ToUpper)
+
+			Expect(out.ValuesUnordered()).To(ContainElements(
+				"FIRST",
+				"SECOND",
+				"THIRD",
+			))
+		})
+	})
+})

--- a/test/gazelle/testdata/basic_hex_tar_no_tests/BUILD.in
+++ b/test/gazelle/testdata/basic_hex_tar_no_tests/BUILD.in
@@ -1,1 +1,2 @@
 # gazelle:erlang_no_tests
+# gazelle:erlang_generate_fewer_bytecode_rules

--- a/test/gazelle/testdata/basic_hex_tar_no_tests/BUILD.out
+++ b/test/gazelle/testdata/basic_hex_tar_no_tests/BUILD.out
@@ -3,6 +3,7 @@ load("@rules_erlang//:erlang_app.bzl", "erlang_app")
 load("@rules_erlang//:untar.bzl", "untar")
 
 # gazelle:erlang_no_tests
+# gazelle:erlang_generate_fewer_bytecode_rules
 
 untar(
     name = "contents",
@@ -40,64 +41,17 @@ erlc_opts(
 )
 
 erlang_bytecode(
-    name = "ebin_aten_beam",
-    srcs = ["src/aten.erl"],
-    outs = ["ebin/aten.beam"],
-    app_name = "aten",
-    erlc_opts = "//:erlc_opts",
-)
-
-erlang_bytecode(
-    name = "ebin_aten_app_beam",
-    srcs = ["src/aten_app.erl"],
-    outs = ["ebin/aten_app.beam"],
-    app_name = "aten",
-    erlc_opts = "//:erlc_opts",
-)
-
-erlang_bytecode(
-    name = "ebin_aten_detect_beam",
-    srcs = ["src/aten_detect.erl"],
-    outs = ["ebin/aten_detect.beam"],
-    app_name = "aten",
-    erlc_opts = "//:erlc_opts",
-)
-
-erlang_bytecode(
-    name = "ebin_aten_detector_beam",
-    srcs = ["src/aten_detector.erl"],
-    outs = ["ebin/aten_detector.beam"],
-    app_name = "aten",
-    erlc_opts = "//:erlc_opts",
-)
-
-erlang_bytecode(
-    name = "ebin_aten_emitter_beam",
-    srcs = ["src/aten_emitter.erl"],
-    outs = ["ebin/aten_emitter.beam"],
-    app_name = "aten",
-    erlc_opts = "//:erlc_opts",
-)
-
-erlang_bytecode(
-    name = "ebin_aten_sink_beam",
-    srcs = ["src/aten_sink.erl"],
-    outs = ["ebin/aten_sink.beam"],
-    app_name = "aten",
-    erlc_opts = "//:erlc_opts",
-)
-
-erlang_bytecode(
-    name = "ebin_aten_sup_beam",
-    srcs = ["src/aten_sup.erl"],
-    outs = ["ebin/aten_sup.beam"],
-    app_name = "aten",
-    erlc_opts = "//:erlc_opts",
-)
-
-filegroup(
-    name = "beam_files",
+    name = "other_beam",
     srcs = [
+        "src/aten.erl",
+        "src/aten_app.erl",
+        "src/aten_detect.erl",
+        "src/aten_detector.erl",
+        "src/aten_emitter.erl",
+        "src/aten_sink.erl",
+        "src/aten_sup.erl",
+    ],
+    outs = [
         "ebin/aten.beam",
         "ebin/aten_app.beam",
         "ebin/aten_detect.beam",
@@ -106,6 +60,15 @@ filegroup(
         "ebin/aten_sink.beam",
         "ebin/aten_sup.beam",
     ],
+    hdrs = [],
+    app_name = "aten",
+    beam = [],
+    erlc_opts = "//:erlc_opts",
+)
+
+filegroup(
+    name = "beam_files",
+    srcs = [":other_beam"],
 )
 
 filegroup(


### PR DESCRIPTION
Produce far fewer `erlang_bytecode` rules in projects with many sources

Can be useful to speed up cold builds on projects that have many interdependent erlang applications, or to possibly reduce the frequency at which gazelle needs to be run