### PR TITLE
Flatten erlc outputs into the ebin dir

### DIFF
--- a/gazelle/erlang_app.go
+++ b/gazelle/erlang_app.go
@@ -95,12 +95,12 @@ func moduleName(src string) string {
 }
 
 func beamFile(src string) string {
-	r := "ebin/" + strings.TrimPrefix(src, "src/")
+	r := "ebin/" + filepath.Base(src)
 	return strings.TrimSuffix(r, ".erl") + ".beam"
 }
 
 func testBeamFile(src string) string {
-	r := "test/" + strings.TrimPrefix(src, "src/")
+	r := "test/" + filepath.Base(src)
 	return strings.TrimSuffix(r, ".erl") + ".beam"
 }
 


### PR DESCRIPTION
Erlang seems to expect that ebin has no subdirs. The module namespace is flat anyway.