### PR TITLE
Fix broken `-I` arg in erlang_bytecode rule when used in the root pkg

### DIFF
--- a/private/erlang_bytecode.bzl
+++ b/private/erlang_bytecode.bzl
@@ -61,7 +61,9 @@ def _impl(ctx):
 
     dest_dir = beam_files[0].dirname
 
-    include_args = ["-I", package_dir]
+    include_args = []
+    if package_dir != "":
+        include_args.extend(["-I", package_dir])
     for dir in unique_dirnames(ctx.files.hdrs):
         include_args.extend(["-I", dir])
 

--- a/private/erlang_bytecode2.bzl
+++ b/private/erlang_bytecode2.bzl
@@ -63,7 +63,9 @@ def _impl(ctx):
         fail(ctx.attr.outs, "do not share a common parent directory")
     out_dir = out_dirs[0]
 
-    include_args = ["-I", package_dir]
+    include_args = []
+    if package_dir != "":
+        include_args.extend(["-I", package_dir])
     for dir in unique_dirnames(ctx.files.hdrs):
         include_args.extend(["-I", dir])
 


### PR DESCRIPTION
This was an accidental side effect of #139 