### PR TITLE
Also consider the erlang_erlc_opt directive when parsing sources

### DIFF
--- a/gazelle/erlang_app.go
+++ b/gazelle/erlang_app.go
@@ -313,7 +313,8 @@ func (erlangApp *ErlangApp) BeamFilesRules(args language.GenerateArgs, erlParser
 		moduleindex = Moduleindex{erlangApp.Name: ownModules.Values(strings.Compare)}
 	}
 
-	erlAttrsBySrc := erlangApp.parseSrcs(args, erlParser, erlangApp.ErlcOpts, erlangApp.Srcs)
+	erlcOpts := mutable_set.Union(erlangConfig.ErlcOpts, erlangApp.ErlcOpts)
+	erlAttrsBySrc := erlangApp.parseSrcs(args, erlParser, erlcOpts, erlangApp.Srcs)
 
 	if erlangConfig.GenerateFewerBytecodeRules {
 		transforms := mutable_set.New[string]()
@@ -442,7 +443,8 @@ func (erlangApp *ErlangApp) testBeamFilesRules(args language.GenerateArgs, erlPa
 		moduleindex = map[string][]string{erlangApp.Name: ownModules.Values(strings.Compare)}
 	}
 
-	erlAttrsBySrc := erlangApp.parseSrcs(args, erlParser, erlangApp.TestErlcOpts, erlangApp.Srcs)
+	testErlcOpts := mutable_set.Union(erlangConfig.TestErlcOpts, erlangApp.TestErlcOpts)
+	erlAttrsBySrc := erlangApp.parseSrcs(args, erlParser, testErlcOpts, erlangApp.Srcs)
 
 	if erlangConfig.GenerateFewerBytecodeRules {
 		transforms := mutable_set.New[string]()

--- a/test/gazelle/erlang_test.go
+++ b/test/gazelle/erlang_test.go
@@ -167,6 +167,25 @@ var _ = Describe("an ErlangApp", func() {
 			Expect(app.Deps.Values(strings.Compare)).To(
 				ConsistOf("baz_app", "fuzz_app"))
 		})
+
+		It("honors erlc opts from directives", func() {
+			fakeParser := fakeErlParser(map[string]*erlang.ErlAttrs{
+				"src/foo.erl": &erlang.ErlAttrs{
+					IncludeLib: []string{"foo.hrl"},
+				},
+			})
+
+			erlangConfigs := args.Config.Exts["erlang"].(erlang.ErlangConfigs)
+			erlangConfig := erlangConfigs[args.Rel]
+			erlangConfig.ErlcOpts.Add("-DCUSTOM")
+
+			app.BeamFilesRules(args, fakeParser)
+
+			Expect(fakeParser.Calls).To(HaveLen(1))
+
+			Expect(fakeParser.Calls[0].macros).To(
+				Equal(erlang.ErlParserMacros{"CUSTOM": nil}))
+		})
 	})
 
 	Describe("Tests Rules", func() {

--- a/test/gazelle/fake_erl_parser.go
+++ b/test/gazelle/fake_erl_parser.go
@@ -4,8 +4,15 @@ import (
 	erlang "github.com/rabbitmq/rules_erlang/gazelle"
 )
 
+type fakeErlParserCall struct {
+	erlFile   string
+	erlangApp *erlang.ErlangApp
+	macros    erlang.ErlParserMacros
+}
+
 type erlParserFake struct {
 	Responses map[string]*erlang.ErlAttrs
+	Calls     []fakeErlParserCall
 }
 
 func fakeErlParser(responses map[string]*erlang.ErlAttrs) *erlParserFake {
@@ -13,6 +20,11 @@ func fakeErlParser(responses map[string]*erlang.ErlAttrs) *erlParserFake {
 }
 
 func (p *erlParserFake) DeepParseErl(erlFile string, erlangApp *erlang.ErlangApp, macros erlang.ErlParserMacros) (*erlang.ErlAttrs, error) {
+	p.Calls = append(p.Calls, fakeErlParserCall{
+		erlFile:   erlFile,
+		erlangApp: erlangApp,
+		macros:    macros,
+	})
 	if r, ok := p.Responses[erlFile]; ok {
 		return r, nil
 	}


### PR DESCRIPTION
This allows `-DSOME_DEFINE=1` flags to affect source analysis