### PR TITLE
Avoid adding empty srcs attrs to filegroup rules from gazelle

### DIFF
--- a/gazelle/erlang_app.go
+++ b/gazelle/erlang_app.go
@@ -614,23 +614,34 @@ func (erlangApp *ErlangApp) allSrcsRules() []*rule.Rule {
 	var rules []*rule.Rule
 
 	srcs := rule.NewRule("filegroup", "srcs")
-	srcs.SetAttr("srcs", multilineList(mutable_set.Union(erlangApp.Srcs, erlangApp.AppSrc).Values(strings.Compare)))
+	srcsSrcs := mutable_set.Union(erlangApp.Srcs, erlangApp.AppSrc).Values(strings.Compare)
+	if len(srcsSrcs) > 0 {
+		srcs.SetAttr("srcs", multilineList(srcsSrcs))
+	}
 	rules = append(rules, srcs)
 
 	private_hdrs := rule.NewRule("filegroup", "private_hdrs")
-	private_hdrs.SetAttr("srcs", multilineList(erlangApp.PrivateHdrs.Values(strings.Compare)))
+	if !erlangApp.PrivateHdrs.IsEmpty() {
+		private_hdrs.SetAttr("srcs", multilineList(erlangApp.PrivateHdrs.Values(strings.Compare)))
+	}
 	rules = append(rules, private_hdrs)
 
 	public_hdrs := rule.NewRule("filegroup", "public_hdrs")
-	public_hdrs.SetAttr("srcs", multilineList(erlangApp.PublicHdrs.Values(strings.Compare)))
+	if !erlangApp.PublicHdrs.IsEmpty() {
+		public_hdrs.SetAttr("srcs", multilineList(erlangApp.PublicHdrs.Values(strings.Compare)))
+	}
 	rules = append(rules, public_hdrs)
 
 	priv := rule.NewRule("filegroup", "priv")
-	priv.SetAttr("srcs", multilineList(erlangApp.Priv.Values(strings.Compare)))
+	if !erlangApp.Priv.IsEmpty() {
+		priv.SetAttr("srcs", multilineList(erlangApp.Priv.Values(strings.Compare)))
+	}
 	rules = append(rules, priv)
 
 	licenses := rule.NewRule("filegroup", "licenses")
-	licenses.SetAttr("srcs", multilineList(erlangApp.LicenseFiles.Values(strings.Compare)))
+	if !erlangApp.LicenseFiles.IsEmpty() {
+		licenses.SetAttr("srcs", multilineList(erlangApp.LicenseFiles.Values(strings.Compare)))
+	}
 	rules = append(rules, licenses)
 
 	hdrs := rule.NewRule("filegroup", "public_and_private_hdrs")

--- a/test/gazelle/testdata/basic_hex_tar/BUILD.out
+++ b/test/gazelle/testdata/basic_hex_tar/BUILD.out
@@ -144,20 +144,11 @@ filegroup(
     ],
 )
 
-filegroup(
-    name = "private_hdrs",
-    srcs = [],
-)
+filegroup(name = "private_hdrs")
 
-filegroup(
-    name = "public_hdrs",
-    srcs = [],
-)
+filegroup(name = "public_hdrs")
 
-filegroup(
-    name = "priv",
-    srcs = [],
-)
+filegroup(name = "priv")
 
 filegroup(
     name = "licenses",

--- a/test/gazelle/testdata/basic_hex_tar_no_tests/BUILD.out
+++ b/test/gazelle/testdata/basic_hex_tar_no_tests/BUILD.out
@@ -83,20 +83,11 @@ filegroup(
     ],
 )
 
-filegroup(
-    name = "private_hdrs",
-    srcs = [],
-)
+filegroup(name = "private_hdrs")
 
-filegroup(
-    name = "public_hdrs",
-    srcs = [],
-)
+filegroup(name = "public_hdrs")
 
-filegroup(
-    name = "priv",
-    srcs = [],
-)
+filegroup(name = "priv")
 
 filegroup(
     name = "licenses",

--- a/test/gazelle/testdata/basic_rebar/BUILD.out
+++ b/test/gazelle/testdata/basic_rebar/BUILD.out
@@ -164,20 +164,11 @@ filegroup(
     ],
 )
 
-filegroup(
-    name = "private_hdrs",
-    srcs = [],
-)
+filegroup(name = "private_hdrs")
 
-filegroup(
-    name = "public_hdrs",
-    srcs = [],
-)
+filegroup(name = "public_hdrs")
 
-filegroup(
-    name = "priv",
-    srcs = [],
-)
+filegroup(name = "priv")
 
 filegroup(
     name = "licenses",

--- a/test/gazelle/testdata/own_header_include_lib/BUILD.out
+++ b/test/gazelle/testdata/own_header_include_lib/BUILD.out
@@ -67,10 +67,7 @@ filegroup(
     ],
 )
 
-filegroup(
-    name = "private_hdrs",
-    srcs = [],
-)
+filegroup(name = "private_hdrs")
 
 filegroup(
     name = "public_hdrs",
@@ -79,15 +76,9 @@ filegroup(
     ],
 )
 
-filegroup(
-    name = "priv",
-    srcs = [],
-)
+filegroup(name = "priv")
 
-filegroup(
-    name = "licenses",
-    srcs = [],
-)
+filegroup(name = "licenses")
 
 filegroup(
     name = "public_and_private_hdrs",


### PR DESCRIPTION
Empty attrs seemed to cycle between being added and removed by gazelle, but avoiding setting the empty attr seems to fix this