### PR TITLE
Allow gazelle to merge the values attr of erlc_opts rules

### DIFF
--- a/gazelle/kinds.go
+++ b/gazelle/kinds.go
@@ -85,8 +85,10 @@ func (l *erlangLang) Kinds() map[string]rule.KindInfo {
 				"visibility": true,
 			},
 			SubstituteAttrs: map[string]bool{},
-			MergeableAttrs:  map[string]bool{},
-			ResolveAttrs:    map[string]bool{},
+			MergeableAttrs: map[string]bool{
+				"values": true,
+			},
+			ResolveAttrs: map[string]bool{},
 		},
 		erlangBytecodeKind: {
 			MatchAttrs: []string{


### PR DESCRIPTION
Otherwise they will only be updated on the first pass. They can always be marked with '# keep' to preserve them if desired.