### PR TITLE
Mark plt rules as "testonly" by default

### DIFF
--- a/dialyze.bzl
+++ b/dialyze.bzl
@@ -14,12 +14,14 @@ DIALYZE_TAG = "dialyze"
 def plt(
         for_target = None,
         apps = None,
+        testonly = True,
         **kwargs):
     if for_target == None and apps == None:
         apps = DEFAULT_PLT_APPS
     _plt(
         for_target = for_target,
         apps = apps,
+        testonly = testonly,
         **kwargs
     )
 

--- a/xref2.bzl
+++ b/xref2.bzl
@@ -29,6 +29,7 @@ def xref(
     )
     xref_query(
         name = name + "-query",
+        testonly = True,
         target = target,
         is_windows = select({
             "@bazel_tools//src/conditions:host_windows": True,


### PR DESCRIPTION
I don't believe it's common practice to include a plt in a release artifact, so while technically a breaking change, is likely not in practice