### PR TITLE
`.ez` support

### DIFF
--- a/ez.bzl
+++ b/ez.bzl
@@ -4,4 +4,10 @@ load(
 )
 
 def ez(**kwargs):
-    _ez(**kwargs)
+    _ez(
+        private_stamp_detect = select({
+            Label("//private:private_stamp_detect"): True,
+            "//conditions:default": False,
+        }),
+        **kwargs
+    )

--- a/ez.bzl
+++ b/ez.bzl
@@ -1,0 +1,7 @@
+load(
+    "//private:ez.bzl",
+    _ez = "ez",
+)
+
+def ez(**kwargs):
+    _ez(**kwargs)

--- a/private/ct.bzl
+++ b/private/ct.bzl
@@ -64,6 +64,7 @@ def _impl(ctx):
     erl_libs_files = erl_libs_contents(
         ctx,
         deps = flat_deps(ctx.attr.deps),
+        ez_deps = ctx.files.ez_deps,
         dir = erl_libs_dir,
     )
 
@@ -294,6 +295,9 @@ ct_test = rule(
         "ct_run_extra_args": attr.string_list(),
         "data": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [ErlangAppInfo]),
+        "ez_deps": attr.label_list(
+            allow_files = [".ez"],
+        ),
         "tools": attr.label_list(cfg = "target"),
         "test_env": attr.string_dict(),
         "sharding_method": attr.string(

--- a/private/ct.bzl
+++ b/private/ct.bzl
@@ -2,8 +2,12 @@ load(
     "@bazel_skylib//rules:common_settings.bzl",
     "BuildSettingInfo",
 )
-load("//:erlang_app_info.bzl", "ErlangAppInfo")
-load(":util.bzl", "erl_libs_contents")
+load(
+    "//:erlang_app_info.bzl",
+    "ErlangAppInfo",
+    "flat_deps",
+)
+load(":util.bzl", "erl_libs_contents2")
 load(
     ":eunit.bzl",
     "package_relative_dirnames",
@@ -57,7 +61,11 @@ def sname(ctx):
 def _impl(ctx):
     erl_libs_dir = ctx.label.name + "_deps"
 
-    erl_libs_files = erl_libs_contents(ctx, dir = erl_libs_dir)
+    erl_libs_files = erl_libs_contents2(
+        ctx,
+        deps = flat_deps(ctx.attr.deps),
+        dir = erl_libs_dir,
+    )
 
     package = ctx.label.package
 

--- a/private/ct.bzl
+++ b/private/ct.bzl
@@ -7,7 +7,7 @@ load(
     "ErlangAppInfo",
     "flat_deps",
 )
-load(":util.bzl", "erl_libs_contents2")
+load(":util.bzl", "erl_libs_contents")
 load(
     ":eunit.bzl",
     "package_relative_dirnames",
@@ -61,7 +61,7 @@ def sname(ctx):
 def _impl(ctx):
     erl_libs_dir = ctx.label.name + "_deps"
 
-    erl_libs_files = erl_libs_contents2(
+    erl_libs_files = erl_libs_contents(
         ctx,
         deps = flat_deps(ctx.attr.deps),
         dir = erl_libs_dir,

--- a/private/dialyze.bzl
+++ b/private/dialyze.bzl
@@ -5,7 +5,7 @@ load(
 )
 load("//:erlang_app_info.bzl", "ErlangAppInfo")
 load("//:util.bzl", "path_join", "windows_path")
-load(":util.bzl", "erl_libs_contents2")
+load(":util.bzl", "erl_libs_contents")
 load(":ct.bzl", "code_paths")
 
 def _impl(ctx):
@@ -22,7 +22,7 @@ def _impl(ctx):
 
     erl_libs_dir = ctx.label.name + "_deps"
 
-    erl_libs_files = erl_libs_contents2(
+    erl_libs_files = erl_libs_contents(
         ctx,
         deps = ctx.attr.libs,
         dir = erl_libs_dir,

--- a/private/erlang_bytecode.bzl
+++ b/private/erlang_bytecode.bzl
@@ -1,6 +1,6 @@
 load("//:erlang_app_info.bzl", "ErlangAppInfo")
 load("//:util.bzl", "path_join")
-load(":util.bzl", "erl_libs_contents")
+load(":util.bzl", "erl_libs_contents2")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
@@ -37,18 +37,19 @@ def _impl(ctx):
         ctx.label.package,
     )
 
-    erl_libs_files = erl_libs_contents(
+    erl_libs_files = erl_libs_contents2(
         ctx,
         target_info = target,
-        transitive = False,
         headers = True,
         dir = erl_libs_dir,
+        deps = ctx.attr.deps,
+        ez_deps = ctx.attr.ez_deps,
     )
 
     # it would be nice to properly compute the path, but ctx.bin_dir.path
     # does not appear to be the whole prefix
     if len(erl_libs_files) > 0:
-        (output_dir, _, path) = erl_libs_files[0].path.partition(erl_libs_dir)
+        (output_dir, _, _path) = erl_libs_files[0].path.partition(erl_libs_dir)
         if output_dir == "":
             fail("Could not compute the ERL_LIBS relative path from {}".format(
                 erl_libs_files[0].path,

--- a/private/erlang_bytecode.bzl
+++ b/private/erlang_bytecode.bzl
@@ -168,6 +168,9 @@ erlang_bytecode = rule(
         "deps": attr.label_list(
             providers = [ErlangAppInfo],
         ),
+        "ez_deps": attr.label_list(
+            allow_files = [".ez"],
+        ),
         "erlc_opts": attr.string_list(),
         "dest": attr.string(
             default = "ebin",

--- a/private/erlang_bytecode.bzl
+++ b/private/erlang_bytecode.bzl
@@ -1,6 +1,6 @@
 load("//:erlang_app_info.bzl", "ErlangAppInfo")
 load("//:util.bzl", "path_join")
-load(":util.bzl", "erl_libs_contents2")
+load(":util.bzl", "erl_libs_contents")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
@@ -37,7 +37,7 @@ def _impl(ctx):
         ctx.label.package,
     )
 
-    erl_libs_files = erl_libs_contents2(
+    erl_libs_files = erl_libs_contents(
         ctx,
         target_info = target,
         headers = True,

--- a/private/erlang_bytecode2.bzl
+++ b/private/erlang_bytecode2.bzl
@@ -1,7 +1,7 @@
-load("//:erlang_app_info.bzl", "ErlangAppInfo")
+load("//:erlang_app_info.bzl", "ErlangAppInfo", "flat_deps")
 load("//:util.bzl", "path_join")
 load(":erlang_bytecode.bzl", "unique_dirnames")
-load(":util.bzl", "erl_libs_contents")
+load(":util.bzl", "erl_libs_contents2")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
@@ -40,13 +40,13 @@ def _impl(ctx):
 
     # this actually just needs to be headers and behaviours, in the context of compiling,
     # though it must include the transitive headers and behaviors. Therefore this file
-    # could have it's own optimized version of `erl_libs_contents`
-    erl_libs_files = erl_libs_contents(
+    # could have it's own optimized version of `erl_libs_contents2`
+    erl_libs_files = erl_libs_contents2(
         ctx,
         target_info = target,
-        transitive = True,
         headers = True,
         dir = erl_libs_dir,
+        deps = flat_deps(ctx.attr.deps),
         ez_deps = ctx.attr.ez_deps,
     )
 

--- a/private/erlang_bytecode2.bzl
+++ b/private/erlang_bytecode2.bzl
@@ -1,7 +1,7 @@
 load("//:erlang_app_info.bzl", "ErlangAppInfo", "flat_deps")
 load("//:util.bzl", "path_join")
 load(":erlang_bytecode.bzl", "unique_dirnames")
-load(":util.bzl", "erl_libs_contents2")
+load(":util.bzl", "erl_libs_contents")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
@@ -40,8 +40,8 @@ def _impl(ctx):
 
     # this actually just needs to be headers and behaviours, in the context of compiling,
     # though it must include the transitive headers and behaviors. Therefore this file
-    # could have it's own optimized version of `erl_libs_contents2`
-    erl_libs_files = erl_libs_contents2(
+    # could have it's own optimized version of `erl_libs_contents`
+    erl_libs_files = erl_libs_contents(
         ctx,
         target_info = target,
         headers = True,

--- a/private/erlang_bytecode2.bzl
+++ b/private/erlang_bytecode2.bzl
@@ -47,6 +47,7 @@ def _impl(ctx):
         transitive = True,
         headers = True,
         dir = erl_libs_dir,
+        ez_deps = ctx.attr.ez_deps,
     )
 
     erl_libs_path = ""
@@ -135,6 +136,9 @@ erlang_bytecode = rule(
         ),
         "deps": attr.label_list(
             providers = [ErlangAppInfo],
+        ),
+        "ez_deps": attr.label_list(
+            allow_files = [".ez"],
         ),
         "erlc_opts": attr.label(
             providers = [ErlcOptsInfo],

--- a/private/eunit.bzl
+++ b/private/eunit.bzl
@@ -64,6 +64,7 @@ def _impl(ctx):
     erl_libs_files = erl_libs_contents(
         ctx,
         deps = deps,
+        ez_deps = ctx.files.ez_deps,
         dir = erl_libs_dir,
     )
 
@@ -185,6 +186,9 @@ eunit_test = rule(
         "eunit_opts": attr.string_list(),
         "data": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [ErlangAppInfo]),
+        "ez_deps": attr.label_list(
+            allow_files = [".ez"],
+        ),
         "tools": attr.label_list(),
         "test_env": attr.string_dict(),
     },

--- a/private/eunit.bzl
+++ b/private/eunit.bzl
@@ -4,7 +4,7 @@ load(
     "path_join",
     "windows_path",
 )
-load(":util.bzl", "erl_libs_contents2")
+load(":util.bzl", "erl_libs_contents")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
@@ -61,7 +61,7 @@ def _impl(ctx):
 
     erl_libs_dir = ctx.label.name + "_deps"
 
-    erl_libs_files = erl_libs_contents2(
+    erl_libs_files = erl_libs_contents(
         ctx,
         deps = deps,
         dir = erl_libs_dir,

--- a/private/ez.bzl
+++ b/private/ez.bzl
@@ -1,0 +1,104 @@
+load("//:erlang_app_info.bzl", "ErlangAppInfo")
+load(
+    "//tools:erlang_toolchain.bzl",
+    "erlang_dirs",
+    "maybe_install_erlang",
+)
+load(":util.bzl", "additional_file_dest_relative_path")
+
+def _extract_version(p):
+    return "erl -eval '{ok, [{application, _, AppInfo}]} = file:consult(\"" + p + "\"), Version = proplists:get_value(vsn, AppInfo), io:fwrite(Version), halt().' -noshell"
+
+def _app_file(lib_info):
+    for f in lib_info.beam:
+        if f.basename.endswith(".app"):
+            return f
+    fail(".app file not found in {}".format(lib_info))
+
+def _impl(ctx):
+    lib_info = ctx.attr.app[ErlangAppInfo]
+
+    (erlang_home, _, runfiles) = erlang_dirs(ctx)
+
+    inputs = runfiles.files.to_list()
+    inputs.extend(lib_info.include)
+    inputs.extend(lib_info.beam)
+    inputs.extend(lib_info.priv)
+
+    workspace = ctx.actions.declare_directory(ctx.label.name)
+    archive = ctx.actions.declare_file("%s.ez" % lib_info.app_name)
+
+    build_directory_commands = [
+        'mkdir "{workspace}/{app_name}-$VERSION"'.format(
+            workspace = workspace.path,
+            app_name = lib_info.app_name,
+        ),
+    ]
+    for f in lib_info.include + lib_info.beam + lib_info.priv:
+        rp = additional_file_dest_relative_path(
+            ctx.attr.app.label,
+            f,
+        )
+        build_directory_commands.extend([
+            "mkdir -p $(dirname \"{workspace}/{app_name}-$VERSION/{rp}\")".format(
+                workspace = workspace.path,
+                app_name = lib_info.app_name,
+                rp = rp,
+            ),
+            "cp {f} {workspace}/{app_name}-$VERSION/{rp}".format(
+                f = f.path,
+                workspace = workspace.path,
+                app_name = lib_info.app_name,
+                rp = rp,
+            ),
+        ])
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = [archive, workspace],
+        command = """set -euxo pipefail
+
+{maybe_install_erlang}
+
+VERSION=$({erlang_home}/bin/{extract_version})
+
+{build_directory_commands}
+
+tree "{workspace}"
+
+"{erlang_home}"/bin/erl \\
+    -noshell \\
+    -eval "zip:create(\\"{workspace}/{app_name}-$VERSION.ez\\",
+            [\\"{app_name}-$VERSION\\"],
+            [{{cwd, \\"{workspace}\\"}},
+             {{compress, all}},
+             {{uncompress, [\\".beam\\",\\".app\\"]}}]),
+           halt()."
+
+tree "{workspace}"
+
+cp "{workspace}/{app_name}-$VERSION.ez" "{archive}"
+""".format(
+            maybe_install_erlang = maybe_install_erlang(ctx),
+            erlang_home = erlang_home,
+            extract_version = _extract_version(_app_file(lib_info).path),
+            build_directory_commands = "\n".join(build_directory_commands),
+            workspace = workspace.path,
+            archive = archive.path,
+            app_name = lib_info.app_name,
+        ),
+        mnemonic = "EZ",
+    )
+
+    return [DefaultInfo(files = depset([archive]))]
+
+ez = rule(
+    implementation = _impl,
+    attrs = {
+        "app": attr.label(
+            providers = [ErlangAppInfo],
+            mandatory = True,
+        ),
+    },
+    toolchains = ["//tools:toolchain_type"],
+)

--- a/private/plt.bzl
+++ b/private/plt.bzl
@@ -1,6 +1,6 @@
 load("//:erlang_app_info.bzl", "ErlangAppInfo", "flat_deps")
 load("//:util.bzl", "path_join")
-load(":util.bzl", "erl_libs_contents2")
+load(":util.bzl", "erl_libs_contents")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
@@ -18,7 +18,7 @@ def _impl(ctx):
 
     erl_libs_dir = ctx.label.name + "_deps"
 
-    erl_libs_files = erl_libs_contents2(
+    erl_libs_files = erl_libs_contents(
         ctx,
         deps = ctx.attr.libs,
         dir = erl_libs_dir,
@@ -41,7 +41,7 @@ def _impl(ctx):
     else:
         deps.extend(flat_deps(ctx.attr.deps))
 
-    target_files = erl_libs_contents2(
+    target_files = erl_libs_contents(
         ctx,
         deps = deps,
         dir = target_files_dir,

--- a/private/plt.bzl
+++ b/private/plt.bzl
@@ -45,6 +45,8 @@ def _impl(ctx):
         ctx,
         deps = deps,
         dir = target_files_dir,
+        expand_ezs = True,
+        ez_deps = ctx.files.ez_deps,
     )
 
     target_files_path = ""
@@ -145,6 +147,9 @@ plt = rule(
         ),
         "deps": attr.label_list(
             providers = [ErlangAppInfo],
+        ),
+        "ez_deps": attr.label_list(
+            allow_files = [".ez"],
         ),
         "for_target": attr.label(
             providers = [ErlangAppInfo],

--- a/private/shell.bzl
+++ b/private/shell.bzl
@@ -17,6 +17,7 @@ def _impl(ctx):
     erl_libs_files = erl_libs_contents(
         ctx,
         deps = flat_deps(ctx.attr.deps),
+        ez_deps = ctx.files.ez_deps,
         dir = erl_libs_dir,
     )
 
@@ -76,6 +77,9 @@ shell = rule(
     attrs = {
         "is_windows": attr.bool(mandatory = True),
         "deps": attr.label_list(providers = [ErlangAppInfo]),
+        "ez_deps": attr.label_list(
+            allow_files = [".ez"],
+        ),
         "extra_erl_args": attr.string_list(),
         "data": attr.label_list(allow_files = True),
     },

--- a/private/shell.bzl
+++ b/private/shell.bzl
@@ -1,10 +1,10 @@
-load("//:erlang_app_info.bzl", "ErlangAppInfo")
+load("//:erlang_app_info.bzl", "ErlangAppInfo", "flat_deps")
 load(
     "//:util.bzl",
     "path_join",
     "windows_path",
 )
-load(":util.bzl", "erl_libs_contents")
+load(":util.bzl", "erl_libs_contents2")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
@@ -14,7 +14,11 @@ load(
 def _impl(ctx):
     erl_libs_dir = ctx.attr.name + "_deps"
 
-    erl_libs_files = erl_libs_contents(ctx, dir = erl_libs_dir)
+    erl_libs_files = erl_libs_contents2(
+        ctx,
+        deps = flat_deps(ctx.attr.deps),
+        dir = erl_libs_dir,
+    )
 
     package = ctx.label.package
 

--- a/private/shell.bzl
+++ b/private/shell.bzl
@@ -4,7 +4,7 @@ load(
     "path_join",
     "windows_path",
 )
-load(":util.bzl", "erl_libs_contents2")
+load(":util.bzl", "erl_libs_contents")
 load(
     "//tools:erlang_toolchain.bzl",
     "erlang_dirs",
@@ -14,7 +14,7 @@ load(
 def _impl(ctx):
     erl_libs_dir = ctx.attr.name + "_deps"
 
-    erl_libs_files = erl_libs_contents2(
+    erl_libs_files = erl_libs_contents(
         ctx,
         deps = flat_deps(ctx.attr.deps),
         dir = erl_libs_dir,

--- a/private/source_tree.bzl
+++ b/private/source_tree.bzl
@@ -24,6 +24,10 @@ def _impl(ctx):
             dest = ctx.actions.declare_file(path_join(dep_path, rp))
             ctx.actions.symlink(output = dest, target_file = src)
             files.append(dest)
+    for ez in ctx.files.ez_deps:
+        dest = ctx.actions.declare_file(path_join(ctx.label.name, ez.basename))
+        ctx.actions.symlink(output = dest, target_file = ez)
+        files.append(dest)
 
     return [DefaultInfo(
         files = depset(files),
@@ -35,6 +39,9 @@ source_tree = rule(
         "deps": attr.label_list(
             providers = [ErlangAppInfo],
             mandatory = True,
+        ),
+        "ez_deps": attr.label_list(
+            allow_files = [".ez"],
         ),
     },
 )

--- a/private/util.bzl
+++ b/private/util.bzl
@@ -25,6 +25,7 @@ def erl_libs_contents2(
         ctx,
         target_info = None,
         deps = [],
+        ez_deps = [],
         headers = False,
         dir = _DEFAULT_ERL_LIBS_DIR):
     erl_libs_files = []
@@ -63,6 +64,10 @@ def erl_libs_contents2(
             dest = ctx.actions.declare_file(path_join(dep_path, rp))
             ctx.actions.symlink(output = dest, target_file = src)
             erl_libs_files.append(dest)
+    for ez in ez_deps:
+        dest = ctx.actions.declare_file(path_join(dir, ez.basename))
+        ctx.actions.symlink(output = dest, target_file = ez)
+        erl_libs_files.append(dest)
     return erl_libs_files
 
 def erl_libs_contents(ctx, transitive = True, **kwargs):

--- a/private/util.bzl
+++ b/private/util.bzl
@@ -25,7 +25,7 @@ def additional_file_dest_relative_path(dep_label, f):
     else:
         return f.short_path
 
-def erl_libs_contents2(
+def erl_libs_contents(
         ctx,
         target_info = None,
         deps = [],

--- a/private/util.bzl
+++ b/private/util.bzl
@@ -1,7 +1,6 @@
 load(
     "//:erlang_app_info.bzl",
     "ErlangAppInfo",
-    "flat_deps",
 )
 load(
     "//:util.bzl",
@@ -87,18 +86,6 @@ def erl_libs_contents2(
             ctx.actions.symlink(output = dest, target_file = ez)
         erl_libs_files.append(dest)
     return erl_libs_files
-
-def erl_libs_contents(ctx, transitive = True, **kwargs):
-    if transitive:
-        deps = flat_deps(ctx.attr.deps)
-    else:
-        deps = ctx.attr.deps
-
-    return erl_libs_contents2(
-        ctx,
-        deps = deps,
-        **kwargs
-    )
 
 def to_erlang_string_list(strings):
     return "[" + ",".join(["\"{}\"".format(s) for s in strings]) + "]"

--- a/private/xref2.bzl
+++ b/private/xref2.bzl
@@ -10,7 +10,7 @@ load(
 )
 load(
     ":util.bzl",
-    "erl_libs_contents2",
+    "erl_libs_contents",
     "to_erlang_atom_list",
     "to_erlang_string_list",
 )
@@ -33,7 +33,7 @@ def _expand_xref_erl(ctx, method = None, arg = None):
     target_info = ctx.attr.target[ErlangAppInfo]
 
     erl_libs_dir = ctx.label.name + "_deps"
-    erl_libs_files = erl_libs_contents2(
+    erl_libs_files = erl_libs_contents(
         ctx,
         deps = flat_deps(target_info.deps) + ctx.attr.additional_libs + ctx.attr.extra_apps,
         dir = erl_libs_dir,

--- a/test/shard_suite/BUILD.bazel
+++ b/test/shard_suite/BUILD.bazel
@@ -33,6 +33,10 @@ load(
     "@rules_erlang//:source_tree.bzl",
     "source_tree",
 )
+load(
+    "@rules_erlang//:ez.bzl",
+    "ez",
+)
 
 APP_NAME = "shard_suite"
 
@@ -102,4 +106,9 @@ ct_suite(
 source_tree(
     name = "source_tree",
     deps = [":erlang_app"],
+)
+
+ez(
+    name = "shard_suite",
+    app = ":erlang_app",
 )


### PR DESCRIPTION
- [x] Adds an `ez` rule for creating archives - https://www.erlang.org/doc/man/code.html#loading-of-code-from-archive-files
- [x] Allows `.ez` files to be used as deps to other rules where appropriate