### PR TITLE
Track gazelle:excludes for resolving umbrella apps correctly

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,6 +30,7 @@ go_deps.from_file(go_mod = "@rules_erlang//:go.mod")
 use_repo(
     go_deps,
     "com_github_bazelbuild_buildtools",
+    "com_github_bmatcuk_doublestar_v4",
     "com_github_google_go_cmp",
     "in_gopkg_yaml_v2",
 )

--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "@bazel_gazelle//resolve:go_default_library",
         "@bazel_gazelle//rule:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@com_github_bmatcuk_doublestar_v4//:doublestar",
         "@com_github_google_go_cmp//cmp",
         "@in_gopkg_yaml_v2//:go_default_library",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.6.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/tools v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/bazelbuild/buildtools v0.0.0-20221004120235-7186f635531b h1:jhiMzJ+8u
 github.com/bazelbuild/buildtools v0.0.0-20221004120235-7186f635531b/go.mod h1:689QdV3hBP7Vo9dJMmzhoYIyo/9iMhEmHkJcnaPRCbo=
 github.com/bazelbuild/rules_go v0.35.0 h1:ViPR65vOrg74JKntAUFY6qZkheBKGB6to7wFd8gCRU4=
 github.com/bazelbuild/rules_go v0.35.0/go.mod h1:ahciH68Viyxtm/gvCQplaAiu8buhf/b+gWswcPjFixI=
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
Previously it was assumed that the Configure pass walked the whole before generation, but this was not true. It meant the approach of using the presence of Config to know a directory was not excluded was not sufficient. Now we track the 'exclude' directive ourselves to know if we should skip a directory when resolving erlang apps within the umbrella repo in gazelle