### PR TITLE
Add a directive for resolving erlang apps explicitly in gazelle

### DIFF
--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -92,7 +92,10 @@ func resolveErlangDeps(c *config.Config, rel string, r *rule.Rule) {
 			if strings.Contains(dep, ":") {
 				resolved[i] = dep
 			} else {
-				if ok, pkg := findAppsDirApp(c, rel, dep); ok {
+				erlangConfig := erlangConfigForRel(c, rel)
+				if r, ok := erlangConfig.Resolves[dep]; ok {
+					resolved[i] = r
+				} else if ok, pkg := findAppsDirApp(c, rel, dep); ok {
 					resolved[i] = fmt.Sprintf("//%s:erlang_app", pkg)
 				} else {
 					resolved[i] = fmt.Sprintf("@%s//:erlang_app", dep)

--- a/test/gazelle/testdata/own_header_include_lib/BUILD.in
+++ b/test/gazelle/testdata/own_header_include_lib/BUILD.in
@@ -1,4 +1,5 @@
 # gazelle:erlang_erlc_opt -DBUILD_WITHOUT_FOO
+# gazelle:erlang_resolve other_lib @foo_proj//apps/other_lib:erlang_app
 
 genrule(
     name = "generate_hrl",

--- a/test/gazelle/testdata/own_header_include_lib/BUILD.out
+++ b/test/gazelle/testdata/own_header_include_lib/BUILD.out
@@ -5,6 +5,7 @@ load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("@rules_erlang//:ct.bzl", "assert_suites2")
 
 # gazelle:erlang_erlc_opt -DBUILD_WITHOUT_FOO
+# gazelle:erlang_resolve other_lib @foo_proj//apps/other_lib:erlang_app
 
 genrule(
     name = "generate_hrl",
@@ -62,6 +63,7 @@ erlang_bytecode(
     hdrs = ["include/own_header_include_lib.hrl"],
     app_name = "own_header_include_lib",
     erlc_opts = "//:erlc_opts",
+    deps = ["@foo_proj//apps/other_lib:erlang_app"],
 )
 
 filegroup(
@@ -129,6 +131,7 @@ erlang_app(
     beam_files = [":beam_files"],
     license_files = [":license_files"],
     priv = [":priv"],
+    deps = ["@foo_proj//apps/other_lib:erlang_app"],
 )
 
 alias(

--- a/test/gazelle/testdata/own_header_include_lib/src/own_header_include_lib.erl
+++ b/test/gazelle/testdata/own_header_include_lib/src/own_header_include_lib.erl
@@ -1,6 +1,7 @@
 -module(own_header_include_lib).
 
 -include_lib("own_header_include_lib/include/own_header_include_lib.hrl").
+-include_lib("other_lib/include/foo.hrl").
 
 main(_) ->
     io:format("Message: ~p~n", [?WHY]).


### PR DESCRIPTION
This is useful when a dependency exists as a sub-package of some other repo