### PR TITLE
Do not generate wildcard (glob/native.glob) "srcs" in gazelle

### DIFF
--- a/test/gazelle/erlang_test.go
+++ b/test/gazelle/erlang_test.go
@@ -407,10 +407,8 @@ var _ = Describe("an ErlangApp", func() {
 			Expect(rules[2].Name()).To(Equal("other_beam"))
 			Expect(rules[2].AttrString("app_name")).To(Equal(app.Name))
 			Expect(rules[2].AttrString("erlc_opts")).To(Equal("//:erlc_opts"))
-			Expect(strings.NewReplacer("\n", "", " ", "").Replace(
-				build.FormatString(rules[2].Attr("srcs"))),
-			).To(
-				Equal("glob([\"src/**/*.erl\"],exclude=[\"src/bar.erl\",\"src/baz.erl\",\"src/xform.erl\",],)"),
+			Expect(rules[2].AttrStrings("srcs")).To(
+				ConsistOf("src/foo.erl"),
 			)
 			Expect(rules[2].AttrString("dest")).To(Equal("ebin"))
 			Expect(rules[2].AttrStrings("beam")).To(

--- a/test/gazelle/testdata/basic_hex_tar_no_tests/BUILD.out
+++ b/test/gazelle/testdata/basic_hex_tar_no_tests/BUILD.out
@@ -50,7 +50,7 @@ erlang_bytecode(
         "src/aten_emitter.erl",
         "src/aten_sink.erl",
         "src/aten_sup.erl",
-    ] + glob(["src/**/*.erl"]),
+    ],
     hdrs = [":public_and_private_hdrs"],
     app_name = "aten",
     dest = "ebin",
@@ -65,6 +65,7 @@ filegroup(
 filegroup(
     name = "srcs",
     srcs = [
+        "src/aten.app.src",
         "src/aten.erl",
         "src/aten_app.erl",
         "src/aten_detect.erl",
@@ -72,26 +73,14 @@ filegroup(
         "src/aten_emitter.erl",
         "src/aten_sink.erl",
         "src/aten_sup.erl",
-    ] + glob([
-        "src/**/*.app.src",
-        "src/**/*.erl",
-    ]),
+    ],
 )
 
-filegroup(
-    name = "private_hdrs",
-    srcs = glob(["src/**/*.hrl"]),
-)
+filegroup(name = "private_hdrs")
 
-filegroup(
-    name = "public_hdrs",
-    srcs = glob(["include/**/*.hrl"]),
-)
+filegroup(name = "public_hdrs")
 
-filegroup(
-    name = "priv",
-    srcs = glob(["priv/**/*"]),
-)
+filegroup(name = "priv")
 
 filegroup(
     name = "license_files",
@@ -99,7 +88,7 @@ filegroup(
         "LICENSE",
         "LICENSE-APACHE2",
         "LICENSE-MPL-RabbitMQ",
-    ] + glob(["LICENSE*"]),
+    ],
 )
 
 filegroup(

--- a/test/gazelle/testdata/basic_rebar_compact_rules/BUILD.out
+++ b/test/gazelle/testdata/basic_rebar_compact_rules/BUILD.out
@@ -52,7 +52,12 @@ plt(
 
 erlang_bytecode(
     name = "other_beam",
-    srcs = glob(["src/**/*.erl"]),
+    srcs = [
+        "src/seshat.erl",
+        "src/seshat_app.erl",
+        "src/seshat_counters_server.erl",
+        "src/seshat_sup.erl",
+    ],
     hdrs = [":public_and_private_hdrs"],
     app_name = "seshat",
     dest = "ebin",
@@ -62,7 +67,12 @@ erlang_bytecode(
 erlang_bytecode(
     name = "test_other_beam",
     testonly = True,
-    srcs = glob(["src/**/*.erl"]),
+    srcs = [
+        "src/seshat.erl",
+        "src/seshat_app.erl",
+        "src/seshat_counters_server.erl",
+        "src/seshat_sup.erl",
+    ],
     hdrs = [":public_and_private_hdrs"],
     app_name = "seshat",
     dest = "test",
@@ -100,30 +110,28 @@ erlang_bytecode(
 
 filegroup(
     name = "srcs",
-    srcs = glob([
-        "src/**/*.app.src",
-        "src/**/*.erl",
-    ]),
+    srcs = [
+        "src/seshat.app.src",
+        "src/seshat.erl",
+        "src/seshat_app.erl",
+        "src/seshat_counters_server.erl",
+        "src/seshat_sup.erl",
+    ],
 )
 
-filegroup(
-    name = "private_hdrs",
-    srcs = glob(["src/**/*.hrl"]),
-)
+filegroup(name = "private_hdrs")
 
-filegroup(
-    name = "public_hdrs",
-    srcs = glob(["include/**/*.hrl"]),
-)
+filegroup(name = "public_hdrs")
 
-filegroup(
-    name = "priv",
-    srcs = glob(["priv/**/*"]),
-)
+filegroup(name = "priv")
 
 filegroup(
     name = "license_files",
-    srcs = glob(["LICENSE*"]),
+    srcs = [
+        "LICENSE",
+        "LICENSE-APACHE2",
+        "LICENSE-MPL-RabbitMQ",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
Gazelle cannot merge such values when updating existing build files, and adding custom logic to do so is non-trivial, especially when applied to BUILD files (app.bzl files are less arduous but still non-trivial).

This means that if new files are added, it's always necessary to run gazelle.

Addresses #185