### PR TITLE
Handle .appup by default

### DIFF
--- a/erlang_app.bzl
+++ b/erlang_app.bzl
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load(":app_file.bzl", "app_file")
 load(":erlang_bytecode.bzl", "erlang_bytecode")
 load(
@@ -120,7 +121,6 @@ def _erlang_app(
         )
 
         beam_files = [":beam_files" if not test else ":test_beam_files"]
-        beam_files += native.glob(["ebin/{}.appup".format(app_name)])
 
     if len(native.glob(["ebin/{}.app".format(app_name)])) == 0:
         if not test:
@@ -144,6 +144,21 @@ def _erlang_app(
         app = ":app_file"
     else:
         app = "ebin/{}.app".format(app_name)
+
+    if len(native.glob(["ebin/{}.appup".format(app_name)])) > 0:
+        appup = "ebin/{}.appup".format(app_name)
+    elif len(native.glob(["src/{}.appup".format(app_name)])) > 0:
+        if not test:
+            copy_file(
+                name = "appup",
+                src = "src/{}.appup".format(app_name),
+                out = "ebin/{}.appup".format(app_name)
+            )
+        appup = ":appup"
+    else:
+        appup = None
+
+    beam_files += [appup] if appup != None else []
 
     if priv == None:
         priv = native.glob(

--- a/erlang_app.bzl
+++ b/erlang_app.bzl
@@ -120,6 +120,7 @@ def _erlang_app(
         )
 
         beam_files = [":beam_files" if not test else ":test_beam_files"]
+        beam_files += native.glob(["ebin/{}.appup".format(app_name)])
 
     if len(native.glob(["ebin/{}.app".format(app_name)])) == 0:
         if not test:

--- a/gazelle/erlang_app_builder.go
+++ b/gazelle/erlang_app_builder.go
@@ -95,11 +95,6 @@ func (builder *ErlangAppBuilder) AddFile(f string, genfile bool) {
 				Path:      f,
 				IsGenFile: genfile,
 			})
-		} else if strings.HasSuffix(f, ".appup") {
-			builder.Ebin.Add(&ErlangAppFile{
-				Path:      f,
-				IsGenFile: genfile,
-			})
 		}
 	} else if strings.HasPrefix(f, "src/") {
 		if strings.HasSuffix(f, ".erl") {

--- a/gazelle/erlang_app_builder.go
+++ b/gazelle/erlang_app_builder.go
@@ -95,8 +95,12 @@ func (builder *ErlangAppBuilder) AddFile(f string, genfile bool) {
 				Path:      f,
 				IsGenFile: genfile,
 			})
+		} else if strings.HasSuffix(f, ".appup") {
+			builder.Ebin.Add(&ErlangAppFile{
+				Path:      f,
+				IsGenFile: genfile,
+			})
 		}
-		// TODO: handle .appup files
 	} else if strings.HasPrefix(f, "src/") {
 		if strings.HasSuffix(f, ".erl") {
 			builder.Srcs.Add(&ErlangAppFile{


### PR DESCRIPTION
Handle the existence of `.appup` files in either `src` or `ebin` directories in the `erlang_app` macro