### PR TITLE
Place the target in the ERL_LIBS dir in the eunit rule

### DIFF
--- a/private/eunit.bzl
+++ b/private/eunit.bzl
@@ -49,6 +49,7 @@ def _impl(ctx):
     if ctx.attr.target != None:
         lib_info = ctx.attr.target[ErlangAppInfo]
         deps.extend(lib_info.deps)
+        deps.append(ctx.attr.target)
         for m in lib_info.beam:
             if m.extension == "beam":
                 module_name = m.basename.removesuffix(".beam")
@@ -73,9 +74,6 @@ def _impl(ctx):
     erl_libs_path = path_join(package, erl_libs_dir)
 
     pa_args = []
-    if ctx.attr.target != None:
-        for dir in package_relative_dirnames(package, ctx.attr.target[ErlangAppInfo].beam):
-            pa_args.extend(["-pa", dir])
     for dir in package_relative_dirnames(package, ctx.files.compiled_suites):
         pa_args.extend(["-pa", dir])
 


### PR DESCRIPTION
Previously the target was added with -pa args, but this will fail if the test target has priv dir contents that are expected at runtime