### PR TITLE
Set ignore_warnings true by default in the plt rule

### DIFF
--- a/private/plt.bzl
+++ b/private/plt.bzl
@@ -155,7 +155,9 @@ plt = rule(
             providers = [ErlangAppInfo],
         ),
         "dialyzer_opts": attr.string_list(),
-        "ignore_warnings": attr.bool(),
+        "ignore_warnings": attr.bool(
+            default = True,
+        ),
     },
     outputs = {
         "plt": ".%{name}.plt",


### PR DESCRIPTION
The plt is used to cache type info for use in the dialyze rule. It's unusual to care about these warnings, as they don't actually apply to the target of the dialyze rule, and can be caused simply by the lack of a complete graph of applications passed to the plt rule.

This is particularly relevant for OTP 26 where unknown functions and types warnings are on by default.