### PR TITLE
Add a summary job to tests in CI to simplify branch rules

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -269,3 +269,17 @@ jobs:
       with:
         name: bazel-testlogs-gazelle
         path: ${{ steps.resolve-test-logs-path.outputs.LOGS_PATH }}/*
+  summary:
+    needs:
+    - test
+    - test-windows
+    - test-bzlmod
+    - test-bzlmod-windows
+    - test-bzlmod-internal-erlang
+    - test-host-erlang-change-detected
+    - test-gazelle-extension
+    runs-on: ubuntu-latest
+    steps:
+    - name: SUMMARY
+      run: |
+        echo "SUCCESS"


### PR DESCRIPTION
This will allow a single rule that does not need to change when erlang versions change