### PR TITLE
Parse `lib:func() rem 3` type expressions in gazelle

### DIFF
--- a/gazelle/erl_attrs_to_json.sh
+++ b/gazelle/erl_attrs_to_json.sh
@@ -166,6 +166,9 @@ record_expression(E, {map, _, Assocs}) ->
 record_expression(E, {cons, _, Head, Tail}) ->
     record_expression(E, Head),
     record_expression(E, Tail);
+record_expression(E, {op, _, _, Lhs, Rhs}) ->
+    record_expression(E, Lhs),
+    record_expression(E, Rhs);
 record_expression(_, _Exp) ->
     %% io:format(standard_error, "E: ~p~n", [Exp]),
     ok.

--- a/test/erl_attrs_to_json/test/basic.erl
+++ b/test/erl_attrs_to_json/test/basic.erl
@@ -10,6 +10,9 @@
 -include_lib("some_lib/include/some_header.hrl").
 -endif.
 
+other_func(X, N) ->
+    other_lib:calc(X) rem N.
+
 myfunc(M) when is_map(M) ->
     try maps:merge(M, #{k2 => other_lib:encode(<<"string">>)})
     catch _:_ ->
@@ -22,6 +25,7 @@ myfunc(M) when is_map(M) ->
 
 main(_) ->
     myfunc(#{k => v}),
+    other_func(10, 3),
     filename:split(some_other_lib:baz()),
     _ = some_other_lib:bar(2),
     other_lib:foo(1).

--- a/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
+++ b/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
@@ -40,7 +40,7 @@ basic(_) ->
                    filename => [split],
                    io => [format],
                    maps => [merge],
-                   other_lib => [foo, finalize, encode],
+                   other_lib => [foo, finalize, encode, calc],
                    some_other_lib => [bar, baz, fizz]
                   }
         },
@@ -55,7 +55,7 @@ basic(_) ->
                    filename => [split],
                    io => [format],
                    maps => [merge],
-                   other_lib => [foo, finalize, encode],
+                   other_lib => [foo, finalize, encode, calc],
                    some_other_lib => [bar, baz, fizz]
                   }
         },


### PR DESCRIPTION
to better detect runtime dependencies