### PR TITLE
Allow multiple erlang builds to be unpacked simultaneously

### DIFF
--- a/repositories/BUILD_external.tpl
+++ b/repositories/BUILD_external.tpl
@@ -10,14 +10,14 @@ load(
 )
 
 erlang_external(
-    name = "otp",
+    name = "otp-%{ERLANG_NAME}",
     erlang_home = "%{ERLANG_HOME}",
     erlang_version = "%{ERLANG_VERSION}",
 )
 
 erlang_toolchain(
     name = "erlang_%{ERLANG_MAJOR}_%{ERLANG_MINOR}_toolchain",
-    otp = ":otp",
+    otp = ":otp-%{ERLANG_NAME}",
     visibility = ["//visibility:public"],
 )
 

--- a/repositories/BUILD_internal.tpl
+++ b/repositories/BUILD_internal.tpl
@@ -10,7 +10,7 @@ load(
 )
 
 erlang_build(
-    name = "otp",
+    name = "otp-%{ERLANG_NAME}",
     version = "%{ERLANG_VERSION}",
     url = "%{URL}",
     strip_prefix = "%{STRIP_PREFIX}",
@@ -19,7 +19,7 @@ erlang_build(
 
 erlang_toolchain(
     name = "erlang_%{ERLANG_MAJOR}_%{ERLANG_MINOR}_toolchain",
-    otp = ":otp",
+    otp = ":otp-%{ERLANG_NAME}",
     visibility = ["//visibility:public"],
 )
 

--- a/repositories/erlang_config.bzl
+++ b/repositories/erlang_config.bzl
@@ -47,6 +47,7 @@ def _impl(repository_ctx):
                 "{}/BUILD.bazel".format(name),
                 Label("//repositories:BUILD_external.tpl"),
                 {
+                    "%{ERLANG_NAME}": name,
                     "%{ERLANG_HOME}": props.erlang_home,
                     "%{ERLANG_VERSION}": props.version,
                     "%{ERLANG_MAJOR}": props.major,
@@ -60,6 +61,7 @@ def _impl(repository_ctx):
                 "{}/BUILD.bazel".format(name),
                 Label("//repositories:BUILD_internal.tpl"),
                 {
+                    "%{ERLANG_NAME}": name,
                     "%{ERLANG_VERSION}": props.version,
                     "%{URL}": props.url,
                     "%{STRIP_PREFIX}": props.strip_prefix or "",


### PR DESCRIPTION
Useful when wiring certain tests

erlangs managed by rules_erlang are each installed at their own path