### PR TITLE
Improve validation of test suites when using sharding

### DIFF
--- a/test/shard_suite/BUILD.bazel
+++ b/test/shard_suite/BUILD.bazel
@@ -101,6 +101,7 @@ ct_suite(
     size = "small",
     additional_srcs = [
         "test/example_suite.erl",
+        "test/example_suite_missing_group.erl",
     ],
 )
 

--- a/test/shard_suite/test/example_suite_missing_group.erl
+++ b/test/shard_suite/test/example_suite_missing_group.erl
@@ -1,0 +1,19 @@
+-module(example_suite_missing_group).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, groups/0]).
+
+all() ->
+    [{group, a_group},
+     {group, missing_group}].
+
+groups() ->
+    [{a_group, [], [one_test, two_test]}].
+
+one_test(_Config) ->
+    ?assertEqual(true, true).
+
+two_test(_Config) ->
+    ?assertEqual(true, true).

--- a/test/shard_suite/test/shard_suite_SUITE.erl
+++ b/test/shard_suite/test/shard_suite_SUITE.erl
@@ -13,7 +13,8 @@ all() -> [
           shard_by_case,
           flatten_shard,
           flatten_shard_with_nested_group,
-          to_ct_run_args
+          to_ct_run_args,
+          when_all_references_missing_group
          ].
 
 structure(_) ->
@@ -87,3 +88,6 @@ to_ct_run_args(_) ->
                  lists:flatten(
                    shard_suite:to_ct_run_args(SuiteModule,
                                               shard_suite:flatten_shard(ShardThree)))).
+
+when_all_references_missing_group(_) ->
+    ?assertThrow(missing_group, shard_suite:structure(example_suite_missing_group)).


### PR DESCRIPTION
If all/0 references groups not in groups/0, we fail fast with a better error message