### PR TITLE
Expose additional erlang_build opts through the erlang_config repo

### DIFF
--- a/bzlmod/extensions.bzl
+++ b/bzlmod/extensions.bzl
@@ -39,6 +39,9 @@ def _erlang_config(ctx):
     strip_prefixs = {}
     sha256s = {}
     erlang_homes = {}
+    pre_configure_cmdss = {}
+    extra_configure_optss = {}
+    post_configure_cmdss = {}
     owners_by_name = {}
 
     for mod in ctx.modules:
@@ -66,6 +69,9 @@ def _erlang_config(ctx):
             urls[erlang.name] = erlang.url
             strip_prefixs[erlang.name] = erlang.strip_prefix
             sha256s[erlang.name] = erlang.sha256
+            pre_configure_cmdss[erlang.name] = erlang.pre_configure_cmds
+            extra_configure_optss[erlang.name] = erlang.extra_configure_opts
+            post_configure_cmdss[erlang.name] = erlang.post_configure_cmds
             owners_by_name[erlang.name] = mod
 
         for erlang in mod.tags.internal_erlang_from_github_release:
@@ -90,6 +96,9 @@ def _erlang_config(ctx):
             urls[erlang.name] = url
             strip_prefixs[erlang.name] = strip_prefix
             sha256s[erlang.name] = sha256
+            pre_configure_cmdss[erlang.name] = erlang.pre_configure_cmds
+            extra_configure_optss[erlang.name] = erlang.extra_configure_opts
+            post_configure_cmdss[erlang.name] = erlang.post_configure_cmds
             owners_by_name[erlang.name] = mod
 
     _erlang_config_rule(
@@ -101,6 +110,9 @@ def _erlang_config(ctx):
         strip_prefixs = strip_prefixs,
         sha256s = sha256s,
         erlang_homes = erlang_homes,
+        pre_configure_cmdss = pre_configure_cmdss,
+        extra_configure_optss = extra_configure_optss,
+        post_configure_cmdss = post_configure_cmdss,
     )
 
 external_erlang_from_path = tag_class(attrs = {
@@ -115,6 +127,9 @@ internal_erlang_from_http_archive = tag_class(attrs = {
     "url": attr.string(),
     "strip_prefix": attr.string(),
     "sha256": attr.string(),
+    "pre_configure_cmds": attr.string_list(),
+    "extra_configure_opts": attr.string_list(),
+    "post_configure_cmds": attr.string_list(),
 })
 
 internal_erlang_from_github_release = tag_class(attrs = {
@@ -125,6 +140,9 @@ internal_erlang_from_github_release = tag_class(attrs = {
         default = DEFAULT_ERLANG_VERSION,
     ),
     "sha256": attr.string(),
+    "pre_configure_cmds": attr.string_list(),
+    "extra_configure_opts": attr.string_list(),
+    "post_configure_cmds": attr.string_list(),
 })
 
 erlang_config = module_extension(

--- a/erlang_app.bzl
+++ b/erlang_app.bzl
@@ -152,7 +152,7 @@ def _erlang_app(
             copy_file(
                 name = "appup",
                 src = "src/{}.appup".format(app_name),
-                out = "ebin/{}.appup".format(app_name)
+                out = "ebin/{}.appup".format(app_name),
             )
         appup = ":appup"
     else:

--- a/repositories/BUILD_internal.tpl
+++ b/repositories/BUILD_internal.tpl
@@ -15,6 +15,9 @@ erlang_build(
     url = "%{URL}",
     strip_prefix = "%{STRIP_PREFIX}",
     sha256 = "%{SHA_256}",
+    pre_configure_cmds = %{PRE_CONFIGURE_CMDS},
+    extra_configure_opts = %{EXTRA_CONFIGURE_OPTS},
+    post_configure_cmds = %{POST_CONFIGURE_CMDS},
 )
 
 erlang_toolchain(

--- a/repositories/erlang_config.bzl
+++ b/repositories/erlang_config.bzl
@@ -19,6 +19,9 @@ def _parse_maybe_semver(version_string):
     else:
         return (parts[0], _ERLANG_VERSION_UNKNOWN.lower())
 
+def _to_string_list(strings):
+    return "[%s]" % ",".join(['"%s"' % s.replace('"', '\\"') for s in strings])
+
 def _impl(repository_ctx):
     rules_erlang_workspace = repository_ctx.attr.rules_erlang_workspace
 
@@ -39,6 +42,9 @@ def _impl(repository_ctx):
             strip_prefix = repository_ctx.attr.strip_prefixs.get(name, None),
             sha256 = repository_ctx.attr.sha256s.get(name, None),
             erlang_home = repository_ctx.attr.erlang_homes.get(name, None),
+            pre_configure_cmds = repository_ctx.attr.pre_configure_cmdss.get(name, []),
+            extra_configure_opts = repository_ctx.attr.extra_configure_optss.get(name, []),
+            post_configure_cmds = repository_ctx.attr.post_configure_cmdss.get(name, []),
         )
 
     for (name, props) in erlang_installations.items():
@@ -69,6 +75,9 @@ def _impl(repository_ctx):
                     "%{ERLANG_MAJOR}": props.major,
                     "%{ERLANG_MINOR}": props.minor,
                     "%{RULES_ERLANG_WORKSPACE}": rules_erlang_workspace,
+                    "%{PRE_CONFIGURE_CMDS}": _to_string_list(props.pre_configure_cmds),
+                    "%{EXTRA_CONFIGURE_OPTS}": _to_string_list(props.extra_configure_opts),
+                    "%{POST_CONFIGURE_CMDS}": _to_string_list(props.post_configure_cmds),
                 },
                 False,
             )
@@ -111,6 +120,9 @@ erlang_config = repository_rule(
         "strip_prefixs": attr.string_dict(),
         "sha256s": attr.string_dict(),
         "erlang_homes": attr.string_dict(),
+        "pre_configure_cmdss": attr.string_list_dict(),
+        "extra_configure_optss": attr.string_list_dict(),
+        "post_configure_cmdss": attr.string_list_dict(),
     },
     environ = [
         ERLANG_HOME_ENV_VAR,

--- a/rules_erlang.bzl
+++ b/rules_erlang.bzl
@@ -59,6 +59,9 @@ def erlang_config(
     urls = {c.name: c.url for c in internal_erlang_configs}
     strip_prefixs = {c.name: c.strip_prefix for c in internal_erlang_configs if c.strip_prefix}
     sha256s = {c.name: c.sha256 for c in internal_erlang_configs if c.sha256}
+    pre_configure_cmdss = {c.name: c.pre_configure_cmds for c in internal_erlang_configs if c.pre_configure_cmds}
+    extra_configure_optss = {c.name: c.extra_configure_opts for c in internal_erlang_configs if c.extra_configure_opts}
+    post_configure_cmdss = {c.name: c.post_configure_cmds for c in internal_erlang_configs if c.post_configure_cmds}
 
     _erlang_config(
         name = "erlang_config",
@@ -68,6 +71,9 @@ def erlang_config(
         urls = urls,
         strip_prefixs = strip_prefixs,
         sha256s = sha256s,
+        pre_configure_cmdss = pre_configure_cmdss,
+        extra_configure_optss = extra_configure_optss,
+        post_configure_cmdss = post_configure_cmdss,
     )
 
 def internal_erlang_from_http_archive(
@@ -75,19 +81,28 @@ def internal_erlang_from_http_archive(
         version = None,
         url = None,
         strip_prefix = None,
-        sha256 = None):
+        sha256 = None,
+        pre_configure_cmds = None,
+        extra_configure_opts = None,
+        post_configure_cmds = None):
     return struct(
         name = name,
         version = version,
         url = url,
         strip_prefix = strip_prefix,
         sha256 = sha256,
+        pre_configure_cmds = pre_configure_cmds,
+        extra_configure_opts = extra_configure_opts,
+        post_configure_cmds = post_configure_cmds,
     )
 
 def internal_erlang_from_github_release(
         name = "internal",
         version = DEFAULT_ERLANG_VERSION,
-        sha256 = None):
+        sha256 = None,
+        pre_configure_cmds = None,
+        extra_configure_opts = None,
+        post_configure_cmds = None):
     url = "https://github.com/erlang/otp/releases/download/OTP-{v}/otp_src_{v}.tar.gz".format(
         v = version,
     )
@@ -101,4 +116,7 @@ def internal_erlang_from_github_release(
         url = url,
         strip_prefix = "otp_src_{}".format(version),
         sha256 = sha256,
+        pre_configure_cmds = pre_configure_cmds,
+        extra_configure_opts = extra_configure_opts,
+        post_configure_cmds = post_configure_cmds,
     )


### PR DESCRIPTION
Allows some customization of erlang as built within the bazel build. For example disabling the jit when compilation happens under emulation.