### PR TITLE
escript_archive rule allows ebin dirs

### DIFF
--- a/erlang_app_info.bzl
+++ b/erlang_app_info.bzl
@@ -68,4 +68,5 @@ erlang_app_info = rule(
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [ErlangAppInfo]),
     },
+    provides = [ErlangAppInfo],
 )


### PR DESCRIPTION
Allow `escript_archive` rule to be used with applications where the list of modules is not known until the rule is executed (after the bazel analysis phase)

Companion to #221 