### PR TITLE
With internal erlangs, only expand erlang if necessary

### DIFF
--- a/tools/erlang_toolchain.bzl
+++ b/tools/erlang_toolchain.bzl
@@ -58,9 +58,11 @@ def maybe_install_erlang(ctx, short_path = False):
         return ""
     else:
         return """\
-tar --extract \\
-    --directory / \\
-    --file {release_tar}""".format(
+if [[ ! -d "{erlang_home}" ]]; then
+    tar --extract \\
+        --directory / \\
+        --file {release_tar} || test -d "{erlang_home}"
+fi""".format(
             release_tar = release_dir_tar.short_path if short_path else release_dir_tar.path,
             erlang_home = info.erlang_home,
         )


### PR DESCRIPTION
If internal erlangs are used without RBE, then multiple actions might try to simultaneously expand erlang