### PR TITLE
Add the optional_applications key to .app files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,6 +65,7 @@ jobs:
           build --enable_runfiles
           build --color=yes
           build --@rules_erlang//:ct_test_windows_logdir_drive_letter=z
+          build --jobs=1
         EOF
     - name: TEST
       working-directory: test
@@ -146,6 +147,7 @@ jobs:
           build --enable_runfiles
           build --color=yes
           build --@rules_erlang//:ct_test_windows_logdir_drive_letter=z
+          build --jobs=1
         EOF
     - name: TEST
       working-directory: test


### PR DESCRIPTION
For now this is not intergrated with the erlang_app macro, as it's not clear what the ideal usage would be

Should that macro have a new optional_deps key mirroring erlang.mk? Should it just expose the arg from the underlying app_file rule? In any case, that can come as a second PR.