### PR TITLE
No longer require sha256sum cli tool to be present on the host

### DIFF
--- a/repositories/BUILD_internal.tpl
+++ b/repositories/BUILD_internal.tpl
@@ -14,7 +14,7 @@ erlang_build(
     version = "%{ERLANG_VERSION}",
     url = "%{URL}",
     strip_prefix = "%{STRIP_PREFIX}",
-    sha256 = "%{SHA_256}",
+    sha256v = "%{SHA_256}",
     pre_configure_cmds = %{PRE_CONFIGURE_CMDS},
     extra_configure_opts = %{EXTRA_CONFIGURE_OPTS},
     post_configure_cmds = %{POST_CONFIGURE_CMDS},

--- a/tools/erlang.bzl
+++ b/tools/erlang.bzl
@@ -55,7 +55,7 @@ def erlang_toolchain_from_http_archive(
         version = version,
         url = url,
         strip_prefix = strip_prefix,
-        sha256 = sha256,
+        sha256v = sha256,
         extra_configure_opts = extra_configure_opts,
         target_compatible_with = [
             erlang_constraint,


### PR DESCRIPTION
in the `erlang_build` rule

Relates to #226