### PR TITLE
Gazelle code parser enhancements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -289,15 +289,19 @@ jobs:
       uses: erlef/setup-beam@v1
       with:
         otp-version: 26
-    - name: TEST GAZELLE PACKAGE
+    - name: CONFIGURE BAZEL
       working-directory: test
       run: |
         cat << EOF >> user.bazelrc
           build --color=yes
         EOF
-
+    - name: TEST GAZELLE PACKAGE (UNIT_SUITE)
+      working-directory: test
+      run: |
         bazelisk test //gazelle:unit_suite
-
+    - name: TEST GAZELLE PACKAGE (INTEGRATION_SUITE)
+      working-directory: test
+      run: |
         bazelisk test //gazelle:integration_suite \
           || bazelisk test //gazelle:integration_suite
     - name: RESOVLE TEST LOGS PATH

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -234,7 +234,8 @@ jobs:
         bazelisk test //... \
           --config=rbe \
           --toolchain_resolution_debug="@rules_erlang.*" \
-          --verbose_failures
+          --verbose_failures \
+          --build_tests_only
     - name: RESOVLE TEST LOGS PATH
       if: always()
       working-directory: test
@@ -302,8 +303,8 @@ jobs:
     - name: TEST GAZELLE PACKAGE (INTEGRATION_SUITE)
       working-directory: test
       run: |
-        bazelisk test //gazelle:integration_suite \
-          || bazelisk test //gazelle:integration_suite
+        bazelisk test //gazelle:integration_suite --test_env PATH \
+          || bazelisk test //gazelle:integration_suite --test_env PATH
     - name: RESOVLE TEST LOGS PATH
       if: always()
       working-directory: test

--- a/BUILD.thoas
+++ b/BUILD.thoas
@@ -1,0 +1,108 @@
+load("@rules_erlang//:erlang_bytecode2.bzl", "erlang_bytecode", "erlc_opts")
+load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+
+erlc_opts(
+    name = "erlc_opts",
+    values = select({
+        "@rules_erlang//:debug_build": [
+            "+debug_info",
+        ],
+        "//conditions:default": [
+            "+debug_info",
+            "+deterministic",
+        ],
+    }),
+    visibility = [":__subpackages__"],
+)
+
+erlang_bytecode(
+    name = "ebin_thoas_beam",
+    srcs = ["src/thoas.erl"],
+    outs = ["ebin/thoas.beam"],
+    app_name = "thoas",
+    erlc_opts = "//:erlc_opts",
+)
+
+erlang_bytecode(
+    name = "ebin_thoas_decode_beam",
+    srcs = ["src/thoas_decode.erl"],
+    outs = ["ebin/thoas_decode.beam"],
+    app_name = "thoas",
+    erlc_opts = "//:erlc_opts",
+)
+
+erlang_bytecode(
+    name = "ebin_thoas_encode_beam",
+    srcs = ["src/thoas_encode.erl"],
+    outs = ["ebin/thoas_encode.beam"],
+    app_name = "thoas",
+    erlc_opts = "//:erlc_opts",
+)
+
+filegroup(
+    name = "beam_files",
+    srcs = [
+        "ebin/thoas.beam",
+        "ebin/thoas_decode.beam",
+        "ebin/thoas_encode.beam",
+    ],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = [
+        "src/thoas.app.src",
+        "src/thoas.erl",
+        "src/thoas_decode.erl",
+        "src/thoas_encode.erl",
+    ],
+)
+
+filegroup(
+    name = "private_hdrs",
+    srcs = [],
+)
+
+filegroup(
+    name = "public_hdrs",
+    srcs = [],
+)
+
+filegroup(
+    name = "priv",
+    srcs = [],
+)
+
+filegroup(
+    name = "licenses",
+    srcs = ["LICENSE"],
+)
+
+filegroup(
+    name = "public_and_private_hdrs",
+    srcs = [
+        ":private_hdrs",
+        ":public_hdrs",
+    ],
+)
+
+filegroup(
+    name = "all_srcs",
+    srcs = [
+        ":public_and_private_hdrs",
+        ":srcs",
+    ],
+)
+
+erlang_app(
+    name = "erlang_app",
+    srcs = [":all_srcs"],
+    app_name = "thoas",
+    beam_files = [":beam_files"],
+)
+
+alias(
+    name = "thoas",
+    actual = ":erlang_app",
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,10 +32,17 @@ erlang_package = use_extension(
     "//bzlmod:extensions.bzl",
     "erlang_package",
 )
+erlang_package.hex_package(
+    name = "thoas",
+    build_file = "@rules_erlang//:BUILD.thoas",
+    sha256 = "442296847aca11db8d25180693d7ca3073d6d7179f66952f07b16415306513b6",
+    version = "0.4.0",
+)
 use_repo(
     erlang_package,
     "getopt_src",
     "xref_runner_src",
+    "thoas",
 )
 
 erlang_config_extension = use_extension(

--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -3,7 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 exports_files([
     "dot_app_to_json.sh",
-    "erl_attrs_to_json.sh",
     "rebar_config_to_json.sh",
 ])
 
@@ -50,12 +49,6 @@ go_library(
 sh_binary(
     name = "dot_app_to_json",
     srcs = ["dot_app_to_json.sh"],
-    visibility = ["//visibility:public"],
-)
-
-sh_binary(
-    name = "erl_attrs_to_json",
-    srcs = ["erl_attrs_to_json.sh"],
     visibility = ["//visibility:public"],
 )
 

--- a/gazelle/def.bzl
+++ b/gazelle/def.bzl
@@ -3,7 +3,7 @@
 
 GAZELLE_ERLANG_RUNTIME_DEPS = [
     "@rules_erlang//gazelle:dot_app_to_json",
-    "@rules_erlang//gazelle:erl_attrs_to_json",
+    "@rules_erlang//gazelle/erl_attrs_to_json:erl_attrs_to_json",
     "@rules_erlang//gazelle:hex_metadata_config_to_json",
     "@rules_erlang//gazelle:rebar_config_to_json",
 ]

--- a/gazelle/erl_attrs_to_json/BUILD.bazel
+++ b/gazelle/erl_attrs_to_json/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_erlang//:erlang_app.bzl", "erlang_app", "test_erlang_app")
+load("//:escript.bzl", "escript_archive")
+
+APP_NAME = "erl_attrs_to_json"
+APP_VERSION = "1.0.0"
+
+DEPS = ["@thoas//:erlang_app"]
+
+erlang_app(
+    name = "erlang_app",
+    app_name = APP_NAME,
+    app_version = APP_VERSION,
+    deps = DEPS,
+)
+
+test_erlang_app(
+    name = "test_erlang_app",
+    app_name = APP_NAME,
+    app_version = APP_VERSION,
+    deps = DEPS,
+)
+
+escript_archive(
+    name = APP_NAME,
+    app = ":erlang_app",
+    visibility = ["//visibility:public"],
+)

--- a/gazelle/erl_attrs_to_json/src/erl_attrs_to_json.erl
+++ b/gazelle/erl_attrs_to_json/src/erl_attrs_to_json.erl
@@ -23,7 +23,7 @@ main(Args) ->
             Map = parse(Filename, Macros, Includes),
             %% io:format(standard_error, "Map: ~p~n", [Map]),
             Json = thoas:encode(Map),
-            io:format("~s", [Json]),
+            io:format("~ts", [Json]),
             % signal to erl_parser_impl.go that the json is written
             io:format(<<0>>),
             main(Args)

--- a/gazelle/erl_parser.go
+++ b/gazelle/erl_parser.go
@@ -14,6 +14,8 @@ func (attrs *ErlAttrs) modules() []string {
 
 type ErlParserMacros map[string]*string
 
+type ErlParserIncludePaths []string
+
 type ErlParser interface {
-	DeepParseErl(string, *ErlangApp, ErlParserMacros) (*ErlAttrs, error)
+	DeepParseErl(string, *ErlangApp, ErlParserMacros, ErlParserIncludePaths) (*ErlAttrs, error)
 }

--- a/gazelle/erl_parser_impl.go
+++ b/gazelle/erl_parser_impl.go
@@ -31,7 +31,7 @@ type erlParserImpl struct{}
 
 func newErlParser() *erlParserImpl {
 	erlParserOnce.Do(func() {
-		scriptRunfile, err := bazel.Runfile("gazelle/erl_attrs_to_json")
+		scriptRunfile, err := bazel.Runfile("gazelle/erl_attrs_to_json/erl_attrs_to_json")
 		if err != nil {
 			log.Printf("failed to initialize erl_attrs_to_json: %v\n", err)
 			os.Exit(1)

--- a/gazelle/erl_parser_impl.go
+++ b/gazelle/erl_parser_impl.go
@@ -37,9 +37,15 @@ func newErlParser() *erlParserImpl {
 			os.Exit(1)
 		}
 
+		escriptCmd, err := exec.LookPath("escript")
+		if err != nil {
+			log.Printf("failed to locate escript command: %v\n", err)
+			os.Exit(1)
+		}
+
 		ctx := context.Background()
 		ctx, parserCancel := context.WithTimeout(ctx, time.Minute*5)
-		cmd := exec.CommandContext(ctx, scriptRunfile)
+		cmd := exec.CommandContext(ctx, escriptCmd, scriptRunfile)
 
 		cmd.Stderr = os.Stderr
 

--- a/gazelle/erl_parser_impl.go
+++ b/gazelle/erl_parser_impl.go
@@ -75,17 +75,19 @@ func newErlParser() *erlParserImpl {
 }
 
 type parseCmd struct {
-	Path   string          `json:"path"`
-	Macros ErlParserMacros `json:"macros"`
+	Path     string                `json:"path"`
+	Macros   ErlParserMacros       `json:"macros"`
+	Includes ErlParserIncludePaths `json:"includes"`
 }
 
-func (p *erlParserImpl) parseErl(erlFilePath string, macros ErlParserMacros) (*ErlAttrs, error) {
+func (p *erlParserImpl) parseErl(erlFilePath string, macros ErlParserMacros, includes ErlParserIncludePaths) (*ErlAttrs, error) {
 	erlParserMutex.Lock()
 	defer erlParserMutex.Unlock()
 
 	command := parseCmd{
 		Path:   erlFilePath,
 		Macros: macros,
+		Includes: includes,
 	}
 
 	encoder := json.NewEncoder(erlParserStdin)
@@ -108,13 +110,13 @@ func (p *erlParserImpl) parseErl(erlFilePath string, macros ErlParserMacros) (*E
 	return &metadata, nil
 }
 
-func (p *erlParserImpl) parseHrl(hrlFile string, erlangApp *ErlangApp, macros ErlParserMacros, erlAttrs *ErlAttrs) error {
+func (p *erlParserImpl) parseHrl(hrlFile string, erlangApp *ErlangApp, macros ErlParserMacros, includes ErlParserIncludePaths, erlAttrs *ErlAttrs) error {
 	hrlFilePath := filepath.Join(erlangApp.RepoRoot, erlangApp.Rel, hrlFile)
 	if _, err := os.Stat(hrlFilePath); errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 
-	hrlAttrs, err := p.parseErl(hrlFilePath, macros)
+	hrlAttrs, err := p.parseErl(hrlFilePath, macros, includes)
 	if err != nil {
 		return err
 	}
@@ -122,7 +124,7 @@ func (p *erlParserImpl) parseHrl(hrlFile string, erlangApp *ErlangApp, macros Er
 		erlAttrs.Include = append(erlAttrs.Include, include)
 		path := erlangApp.pathFor(hrlFile, include)
 		if path != "" {
-			err := p.parseHrl(path, erlangApp, macros, erlAttrs)
+			err := p.parseHrl(path, erlangApp, macros, includes, erlAttrs)
 			if err != nil {
 				return err
 			}
@@ -132,13 +134,14 @@ func (p *erlParserImpl) parseHrl(hrlFile string, erlangApp *ErlangApp, macros Er
 	return nil
 }
 
-func (p *erlParserImpl) DeepParseErl(erlFile string, erlangApp *ErlangApp, macros ErlParserMacros) (*ErlAttrs, error) {
+func (p *erlParserImpl) DeepParseErl(erlFile string, erlangApp *ErlangApp,
+	macros ErlParserMacros, includes ErlParserIncludePaths) (*ErlAttrs, error) {
 	erlFilePath := filepath.Join(erlangApp.RepoRoot, erlangApp.Rel, erlFile)
 	if _, err := os.Stat(erlFilePath); errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
 
-	rootAttrs, err := p.parseErl(erlFilePath, macros)
+	rootAttrs, err := p.parseErl(erlFilePath, macros, includes)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +149,7 @@ func (p *erlParserImpl) DeepParseErl(erlFile string, erlangApp *ErlangApp, macro
 	for _, include := range rootAttrs.Include {
 		path := erlangApp.pathFor(erlFile, include)
 		if path != "" {
-			err := p.parseHrl(path, erlangApp, macros, rootAttrs)
+			err := p.parseHrl(path, erlangApp, macros, includes, rootAttrs)
 			if err != nil {
 				return nil, err
 			}

--- a/gazelle/erlang_app.go
+++ b/gazelle/erlang_app.go
@@ -116,7 +116,7 @@ func multilineList[T any](values []T) build.Expr {
 }
 
 func (erlangApp *ErlangApp) pathFor(from, include string) string {
-	directPath := filepath.Join(filepath.Dir(from), include)
+	directPath := filepath.Join(from, include)
 	privatePath := filepath.Join("src", include)
 	for p, ok := range erlangApp.PrivateHdrs {
 		if ok {

--- a/gazelle/erlang_app.go
+++ b/gazelle/erlang_app.go
@@ -650,7 +650,7 @@ func (erlangApp *ErlangApp) testPathFor(from, include string) string {
 	if standardPath != "" {
 		return standardPath
 	}
-	directPath := filepath.Join(filepath.Dir(from), include)
+	directPath := filepath.Join(from, include)
 	for p, ok := range erlangApp.TestHdrs {
 		if ok {
 			if p.Path == include {

--- a/gazelle/erlang_app_builder.go
+++ b/gazelle/erlang_app_builder.go
@@ -185,8 +185,14 @@ func (builder *ErlangAppBuilder) Build(args language.GenerateArgs, erlParser Erl
 
 			var err error
 
+			includes := []string{
+				filepath.Join(erlangApp.RepoRoot, erlangApp.Rel),
+				filepath.Join(erlangApp.RepoRoot, erlangApp.Rel, "include"),
+				filepath.Join(erlangApp.RepoRoot, erlangApp.Rel, "src"),
+			}
+
 			erlcOpts := mutable_set.Union(erlangConfig.ErlcOpts, erlangApp.ErlcOpts)
-			src.ErlAttrs, err = erlParser.DeepParseErl(src.Path, &erlangApp, macros(erlcOpts))
+			src.ErlAttrs, err = erlParser.DeepParseErl(src.Path, &erlangApp, macros(erlcOpts), includes)
 			if err != nil {
 				log.Fatalf("ERROR: %v\n", err)
 			}
@@ -194,7 +200,7 @@ func (builder *ErlangAppBuilder) Build(args language.GenerateArgs, erlParser Erl
 			Log(args.Config, "        Parsed", src.path(), "->", actualPath)
 
 			testErlcOpts := mutable_set.Union(erlangConfig.TestErlcOpts, erlangApp.TestErlcOpts)
-			src.TestErlAttrs, err = erlParser.DeepParseErl(src.Path, &erlangApp, macros(testErlcOpts))
+			src.TestErlAttrs, err = erlParser.DeepParseErl(src.Path, &erlangApp, macros(testErlcOpts), includes)
 			if err != nil {
 				log.Fatalf("ERROR: %v\n", err)
 			}
@@ -210,7 +216,12 @@ func (builder *ErlangAppBuilder) Build(args language.GenerateArgs, erlParser Erl
 			var err error
 
 			testErlcOpts := mutable_set.Union(erlangConfig.TestErlcOpts, erlangApp.TestErlcOpts)
-			src.TestErlAttrs, err = erlParser.DeepParseErl(src.Path, &erlangApp, macros(testErlcOpts))
+			src.TestErlAttrs, err = erlParser.DeepParseErl(src.Path, &erlangApp, macros(testErlcOpts), []string{
+				filepath.Join(erlangApp.RepoRoot, erlangApp.Rel),
+				filepath.Join(erlangApp.RepoRoot, erlangApp.Rel, "include"),
+				filepath.Join(erlangApp.RepoRoot, erlangApp.Rel, "src"),
+				filepath.Join(erlangApp.RepoRoot, erlangApp.Rel, "test"),
+			})
 			if err != nil {
 				log.Fatalf("ERROR: %v\n", err)
 			}

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -67,3 +67,9 @@ filegroup(
 )
 """,
     )
+    hex_archive(
+        name = "thoas",
+        version = "0.4.0",
+        sha256 = "442296847aca11db8d25180693d7ca3073d6d7179f66952f07b16415306513b6",
+        build_file = "@rules_erlang//:BUILD.thoas",
+    )

--- a/test/erl_attrs_to_json/BUILD.bazel
+++ b/test/erl_attrs_to_json/BUILD.bazel
@@ -101,6 +101,7 @@ ct_suite(
     name = "erl_attrs_to_json_SUITE",
     size = "small",
     data = [
+        "test/basic.hrl",
         "test/basic.erl",
         "test/test.erl",
     ],

--- a/test/erl_attrs_to_json/BUILD.bazel
+++ b/test/erl_attrs_to_json/BUILD.bazel
@@ -1,21 +1,4 @@
 load(
-    "@rules_erlang//:app_file.bzl",
-    "app_file",
-)
-load(
-    "@rules_erlang//:erlang_bytecode.bzl",
-    "erlang_bytecode",
-)
-load(
-    "@rules_erlang//:erlang_app_info.bzl",
-    "erlang_app_info",
-)
-load(
-    "@rules_erlang//:erlang_app.bzl",
-    "DEFAULT_ERLC_OPTS",
-    "DEFAULT_TEST_ERLC_OPTS",
-)
-load(
     "@rules_erlang//:xref2.bzl",
     "xref",
 )
@@ -31,59 +14,14 @@ load(
     "ct_suite",
 )
 
-genrule(
-    name = "src",
-    srcs = ["@rules_erlang//gazelle:erl_attrs_to_json.sh"],
-    outs = ["src/erl_attrs_to_json.erl"],
-    cmd = """\
-echo "-module(erl_attrs_to_json)." > $@
-tail -n +4 $< >> $@
-""",
-)
-
-APP_NAME = "erl_attrs_to_json"
-
-APP_VERSION = "1.0.0"
-
-erlang_bytecode(
-    name = "beam_files",
-    srcs = ["src/erl_attrs_to_json.erl"],
-    dest = "ebin",
-    erlc_opts = DEFAULT_ERLC_OPTS,
-)
-
-erlang_bytecode(
-    name = "test_beam_files",
-    testonly = True,
-    srcs = ["src/erl_attrs_to_json.erl"],
-    dest = "test",
-    erlc_opts = DEFAULT_TEST_ERLC_OPTS + [
-        "+nowarn_export_all",
-    ],
-)
-
-app_file(
-    name = "app_file",
-    app_name = APP_NAME,
-    app_version = APP_VERSION,
-    modules = [":beam_files"],
-)
-
-erlang_app_info(
+alias(
     name = "erlang_app",
-    srcs = ["src/erl_attrs_to_json.erl"],
-    app = ":app_file",
-    app_name = APP_NAME,
-    beam = [":beam_files"],
+    actual = "@rules_erlang//gazelle/erl_attrs_to_json:erlang_app",
 )
 
-erlang_app_info(
+alias(
     name = "test_erlang_app",
-    testonly = True,
-    srcs = ["src/erl_attrs_to_json.erl"],
-    app = ":app_file",
-    app_name = APP_NAME,
-    beam = [":test_beam_files"],
+    actual = "@rules_erlang//gazelle/erl_attrs_to_json:test_erlang_app",
 )
 
 xref()
@@ -91,6 +29,7 @@ xref()
 plt(
     name = "base_plt",
     apps = DEFAULT_PLT_APPS,
+    deps = ["@thoas//:erlang_app"],
 )
 
 dialyze(

--- a/test/erl_attrs_to_json/test/basic.erl
+++ b/test/erl_attrs_to_json/test/basic.erl
@@ -2,6 +2,7 @@
 
 -compile({parse_transform, my_pt}).
 
+-include("basic.hrl").
 -include("my_header.hrl").
 
 -export([main/1]).
@@ -23,9 +24,19 @@ myfunc(M) when is_map(M) ->
     io:format("Hello~n", []),
     {ok, some_other_lib:fizz()}.
 
+on_a_record_func(#'v1_0.source'{name = foo} = R) ->
+    ?SOME_CONST;
+on_a_record_func(#'v1_0.source'{name = Name} = R) ->
+    case Name of
+        _ -> case other_lib:bar(R) of
+            _ -> ok
+        end
+    end.
+
 main(_) ->
     myfunc(#{k => v}),
     other_func(10, 3),
+    on_a_record_func(#'v1_0.source'{}),
     filename:split(some_other_lib:baz()),
     _ = some_other_lib:bar(2),
     other_lib:foo(1).

--- a/test/erl_attrs_to_json/test/basic.hrl
+++ b/test/erl_attrs_to_json/test/basic.hrl
@@ -1,0 +1,1 @@
+-define(SOME_CONST, 10).

--- a/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
+++ b/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
@@ -6,45 +6,41 @@
 -compile(export_all).
 
 all() -> [
-          parse_command,
+          conform_command,
           basic,
           test_src
          ].
 
-parse_command(_) ->
+conform_command(_) ->
     Command1 = thoas:encode(
                  #{path => <<"/some/path/foo.erl">>,
                    macros => #{'TEST' => null},
                    includes => [<<"/some/path">>]}),
     ct:pal(?LOW_IMPORTANCE, "Command1: ~p", [Command1]),
+    {ok, Command1Decoded} = thoas:decode(Command1),
     ?assertEqual(
        #{path => "/some/path/foo.erl",
          macros => ['TEST'],
          includes => ["/some/path"]},
-       erl_attrs_to_json:parse_command(binary_to_list(Command1))),
+       erl_attrs_to_json:conform_command(Command1Decoded)),
 
     Command2 = thoas:encode(
                  #{path => <<"/some/path/bar.erl">>,
                    macros => #{'TEST' => <<"1">>},
                    includes => [<<"/some/path">>]}),
     ct:pal(?LOW_IMPORTANCE, "Command2: ~p", [Command2]),
+    {ok, Command2Decoded} = thoas:decode(Command2),
     ?assertEqual(
        #{path => "/some/path/bar.erl",
          macros => [{'TEST', "1"}],
          includes => ["/some/path"]},
-       erl_attrs_to_json:parse_command(binary_to_list(Command2))),
-
-    Command3 = "{\"path\":\"/private/var/folders/49/28hfxmws7651mjmlvfn1_h7h0000gp/T/gazelle_test429687135/rebar_with_ct_suites/src/osiris.erl\",\"macros\":{},\"includes\":[\"/private/var/folders/49/28hfxmws7651mjmlvfn1_h7h0000gp/T/gazelle_test429687135/rebar_with_ct_suites\",\"/private/var/folders/49/28hfxmws7651mjmlvfn1_h7h0000gp/T/gazelle_test429687135/rebar_with_ct_suites/include\",\"/private/var/folders/49/28hfxmws7651mjmlvfn1_h7h0000gp/T/gazelle_test429687135/rebar_with_ct_suites/src\"]}",
-    ct:pal(?LOW_IMPORTANCE, "Command3: ~s", [Command3]),
-    ?assertMatch(
-      #{path := "/private/var/folders/49/28hfxmws7651mjmlvfn1_h7h0000gp/T/gazelle_test429687135/rebar_with_ct_suites/src/osiris.erl"},
-      erl_attrs_to_json:parse_command(Command3)).
+       erl_attrs_to_json:conform_command(Command2Decoded)).
 
 basic(_) ->
     ?assertEqual(
        #{
          include_lib => [],
-         include => ["my_header.hrl", "basic.hrl"],
+         include => [<<"my_header.hrl">>, <<"basic.hrl">>],
          behaviour => [],
          parse_transform => [my_pt],
          call => #{
@@ -58,8 +54,8 @@ basic(_) ->
        erl_attrs_to_json:parse(fixture_path("test/basic.erl"), [], ["test"])),
     ?assertEqual(
        #{
-         include_lib => ["some_lib/include/some_header.hrl"],
-         include => ["my_header.hrl", "basic.hrl"],
+         include_lib => [<<"some_lib/include/some_header.hrl">>],
+         include => [<<"my_header.hrl">>, <<"basic.hrl">>],
          behaviour => [],
          parse_transform => [my_pt],
          call => #{
@@ -75,7 +71,7 @@ basic(_) ->
 test_src(_) ->
    ?assertMatch(
       #{
-        include_lib := ["proper/include/proper.hrl"],
+        include_lib := [<<"proper/include/proper.hrl">>],
         parse_transform := [eunit_autoexport],
         call := #{
          proper := [counterexample]

--- a/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
+++ b/test/erl_attrs_to_json/test/erl_attrs_to_json_SUITE.erl
@@ -14,52 +14,63 @@ all() -> [
 parse_command(_) ->
     Command1 = thoas:encode(
                  #{path => <<"/some/path/foo.erl">>,
-                   macros => #{'TEST' => null}}),
+                   macros => #{'TEST' => null},
+                   includes => [<<"/some/path">>]}),
     ct:pal(?LOW_IMPORTANCE, "Command1: ~p", [Command1]),
     ?assertEqual(
        #{path => "/some/path/foo.erl",
-         macros => ['TEST']},
+         macros => ['TEST'],
+         includes => ["/some/path"]},
        erl_attrs_to_json:parse_command(binary_to_list(Command1))),
+
     Command2 = thoas:encode(
                  #{path => <<"/some/path/bar.erl">>,
-                   macros => #{'TEST' => <<"1">>}}),
+                   macros => #{'TEST' => <<"1">>},
+                   includes => [<<"/some/path">>]}),
     ct:pal(?LOW_IMPORTANCE, "Command2: ~p", [Command2]),
     ?assertEqual(
        #{path => "/some/path/bar.erl",
-         macros => [{'TEST', "1"}]},
-       erl_attrs_to_json:parse_command(binary_to_list(Command2))).
+         macros => [{'TEST', "1"}],
+         includes => ["/some/path"]},
+       erl_attrs_to_json:parse_command(binary_to_list(Command2))),
+
+    Command3 = "{\"path\":\"/private/var/folders/49/28hfxmws7651mjmlvfn1_h7h0000gp/T/gazelle_test429687135/rebar_with_ct_suites/src/osiris.erl\",\"macros\":{},\"includes\":[\"/private/var/folders/49/28hfxmws7651mjmlvfn1_h7h0000gp/T/gazelle_test429687135/rebar_with_ct_suites\",\"/private/var/folders/49/28hfxmws7651mjmlvfn1_h7h0000gp/T/gazelle_test429687135/rebar_with_ct_suites/include\",\"/private/var/folders/49/28hfxmws7651mjmlvfn1_h7h0000gp/T/gazelle_test429687135/rebar_with_ct_suites/src\"]}",
+    ct:pal(?LOW_IMPORTANCE, "Command3: ~s", [Command3]),
+    ?assertMatch(
+      #{path := "/private/var/folders/49/28hfxmws7651mjmlvfn1_h7h0000gp/T/gazelle_test429687135/rebar_with_ct_suites/src/osiris.erl"},
+      erl_attrs_to_json:parse_command(Command3)).
 
 basic(_) ->
     ?assertEqual(
        #{
          include_lib => [],
-         include => ["my_header.hrl"],
+         include => ["my_header.hrl", "basic.hrl"],
          behaviour => [],
          parse_transform => [my_pt],
          call => #{
                    filename => [split],
                    io => [format],
                    maps => [merge],
-                   other_lib => [foo, finalize, encode, calc],
+                   other_lib => [foo, bar, finalize, encode, calc],
                    some_other_lib => [bar, baz, fizz]
                   }
         },
-       erl_attrs_to_json:parse(fixture_path("test/basic.erl"), [])),
+       erl_attrs_to_json:parse(fixture_path("test/basic.erl"), [], ["test"])),
     ?assertEqual(
        #{
          include_lib => ["some_lib/include/some_header.hrl"],
-         include => ["my_header.hrl"],
+         include => ["my_header.hrl", "basic.hrl"],
          behaviour => [],
          parse_transform => [my_pt],
          call => #{
                    filename => [split],
                    io => [format],
                    maps => [merge],
-                   other_lib => [foo, finalize, encode, calc],
+                   other_lib => [foo, bar, finalize, encode, calc],
                    some_other_lib => [bar, baz, fizz]
                   }
         },
-       erl_attrs_to_json:parse(fixture_path("test/basic.erl"), ['TEST'])).
+       erl_attrs_to_json:parse(fixture_path("test/basic.erl"), ['TEST'], ["test"])).
 
 test_src(_) ->
    ?assertMatch(
@@ -70,7 +81,7 @@ test_src(_) ->
          proper := [counterexample]
         }
        },
-      erl_attrs_to_json:parse(fixture_path("test/test.erl"), ['TEST'])).
+      erl_attrs_to_json:parse(fixture_path("test/test.erl"), ['TEST'], ["test"])).
 
 fixture_path(File) ->
     filename:join([os:getenv("TEST_SRCDIR"),

--- a/test/gazelle/BUILD.bazel
+++ b/test/gazelle/BUILD.bazel
@@ -96,7 +96,7 @@ genrule(
     outs = ["erl_attrs_to_json_wrapper.sh"],
     cmd = """\
 cat << 'EOF' > $@
-jq -nc '{"path":"'$$1'","macros":{}}' \
+jq -nc '{"path":"'$$1'","macros":{},"includes":["'$$(dirname $$1)'"]}' \
     | $(location @rules_erlang//gazelle:erl_attrs_to_json) \
     | jq
 EOF

--- a/test/gazelle/BUILD.bazel
+++ b/test/gazelle/BUILD.bazel
@@ -14,7 +14,7 @@ go_test(
     data = [
         ":gazelle_erlang_binary",
         "@rules_erlang//gazelle:dot_app_to_json",
-        "@rules_erlang//gazelle:erl_attrs_to_json",
+        "@rules_erlang//gazelle/erl_attrs_to_json:erl_attrs_to_json",
         "@rules_erlang//gazelle:hex_metadata_config_to_json",
         "@rules_erlang//gazelle:rebar_config_to_json",
     ] + glob(["testdata/**"]),
@@ -97,12 +97,12 @@ genrule(
     cmd = """\
 cat << 'EOF' > $@
 jq -nc '{"path":"'$$1'","macros":{},"includes":["'$$(dirname $$1)'"]}' \
-    | $(location @rules_erlang//gazelle:erl_attrs_to_json) \
+    | $(location @rules_erlang//gazelle/erl_attrs_to_json:erl_attrs_to_json) \
     | jq
 EOF
 """,
     executable = True,
     tools = [
-        "@rules_erlang//gazelle:erl_attrs_to_json",
+        "@rules_erlang//gazelle/erl_attrs_to_json:erl_attrs_to_json",
     ],
 )

--- a/test/gazelle/fake_erl_parser.go
+++ b/test/gazelle/fake_erl_parser.go
@@ -8,6 +8,7 @@ type fakeErlParserCall struct {
 	erlFile   string
 	erlangApp *erlang.ErlangApp
 	macros    erlang.ErlParserMacros
+	includes  erlang.ErlParserIncludePaths
 }
 
 type erlParserFake struct {
@@ -19,11 +20,13 @@ func fakeErlParser(responses map[string]*erlang.ErlAttrs) *erlParserFake {
 	return &erlParserFake{Responses: responses}
 }
 
-func (p *erlParserFake) DeepParseErl(erlFile string, erlangApp *erlang.ErlangApp, macros erlang.ErlParserMacros) (*erlang.ErlAttrs, error) {
+func (p *erlParserFake) DeepParseErl(erlFile string, erlangApp *erlang.ErlangApp,
+	macros erlang.ErlParserMacros, includes erlang.ErlParserIncludePaths) (*erlang.ErlAttrs, error) {
 	p.Calls = append(p.Calls, fakeErlParserCall{
 		erlFile:   erlFile,
 		erlangApp: erlangApp,
 		macros:    macros,
+		includes:  includes,
 	})
 	if r, ok := p.Responses[erlFile]; ok {
 		return r, nil


### PR DESCRIPTION
When using `epp:parse_file/2` to process erlang sources and infer dependencies, we now supply the basic header search paths to the parser

This should reduce errors in parsing and provide better dependency detection