### PR TITLE
Coverage support for linux/macos builds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -253,9 +253,9 @@ jobs:
     steps:
     - name: CHECKOUT
       uses: actions/checkout@v4
-    - name: INSTALL LCOV
-      run: |
-        sudo apt-get install -y lcov
+    # - name: INSTALL LCOV
+    #   run: |
+    #     sudo apt-get install -y lcov
     - name: CONFIGURE ERLANG
       uses: erlef/setup-beam@v1
       with:
@@ -264,11 +264,11 @@ jobs:
       working-directory: test
       run: |
         bazelisk coverage --combined_report=lcov //...
-    - name: GENHTML
-      working-directory: test
-      run: |
-        head "$(bazel info output_path)/_coverage/_coverage_report.dat"
-        genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
+    # - name: GENHTML
+    #   working-directory: test
+    #   run: |
+    #     head "$(bazel info output_path)/_coverage/_coverage_report.dat"
+    #     genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
     - name: RESOVLE TEST LOGS PATH
       if: always()
       working-directory: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -248,6 +248,33 @@ jobs:
       with:
         name: bazel-testlogs-bzlmod-internal-erlang
         path: ${{ steps.resolve-test-logs-path.outputs.LOGS_PATH }}/*
+  test-bzlmod-coverage:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: CHECKOUT
+      uses: actions/checkout@v4
+    - name: CONFIGURE ERLANG
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: 26
+    - name: COVERAGE
+      working-directory: test
+      run: |
+        bazelisk coverage --combined_report=lcov //...
+
+        genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
+    - name: RESOVLE TEST LOGS PATH
+      if: always()
+      working-directory: test
+      run: |
+        echo "::set-output name=LOGS_PATH::$(readlink -f bazel-testlogs)"
+      id: resolve-test-logs-path
+    - name: CAPTURE TEST LOGS
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: bazel-testlogs-bzlmod-coverage
+        path: ${{ steps.resolve-test-logs-path.outputs.LOGS_PATH }}/*
   test-host-erlang-change-detected:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -264,7 +264,10 @@ jobs:
       working-directory: test
       run: |
         bazelisk coverage --combined_report=lcov //...
-
+    - name: GENHTML
+      working-directory: test
+      run: |
+        head "$(bazel info output_path)/_coverage/_coverage_report.dat"
         genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
     - name: RESOVLE TEST LOGS PATH
       if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -253,6 +253,9 @@ jobs:
     steps:
     - name: CHECKOUT
       uses: actions/checkout@v4
+    - name: INSTALL LCOV
+      run: |
+        sudo apt-get install -y lcov
     - name: CONFIGURE ERLANG
       uses: erlef/setup-beam@v1
       with:

--- a/ct.bzl
+++ b/ct.bzl
@@ -73,6 +73,7 @@ def ct_suite_variant(
 
     _ct_test(
         shard_suite = Label("@rules_erlang//tools/shard_suite:shard_suite"),
+        coverdata_to_lcov = Label("@rules_erlang//tools/coverdata_to_lcov:coverdata_to_lcov"),
         name = name,
         suite_name = suite_name,
         is_windows = select({
@@ -93,6 +94,7 @@ def ct_test(
         compiled_suites = None,
         deps = [":test_erlang_app"],
         shard_suite = Label("@rules_erlang//tools/shard_suite:shard_suite"),
+        coverdata_to_lcov = Label("@rules_erlang//tools/coverdata_to_lcov:coverdata_to_lcov"),
         **kwargs):
     if suite_name == None or suite_name == "":
         suite_name = name
@@ -104,6 +106,7 @@ def ct_test(
         compiled_suites = compiled_suites,
         deps = deps,
         shard_suite = shard_suite,
+        coverdata_to_lcov = coverdata_to_lcov,
         is_windows = select({
             "@bazel_tools//src/conditions:host_windows": True,
             "//conditions:default": False,

--- a/eunit.bzl
+++ b/eunit.bzl
@@ -35,6 +35,7 @@ def eunit(
 
     eunit_test(
         name = "eunit",
+        coverdata_to_lcov = Label("@rules_erlang//tools/coverdata_to_lcov:coverdata_to_lcov"),
         is_windows = select({
             "@bazel_tools//src/conditions:host_windows": True,
             "//conditions:default": False,

--- a/eunit2.bzl
+++ b/eunit2.bzl
@@ -2,9 +2,11 @@ load("//private:eunit.bzl", "eunit_test")
 
 def eunit(
         name = "eunit",
+        coverdata_to_lcov = Label("@rules_erlang//tools/coverdata_to_lcov:coverdata_to_lcov"),
         **kwargs):
     eunit_test(
         name = name,
+        coverdata_to_lcov = coverdata_to_lcov,
         is_windows = select({
             "@bazel_tools//src/conditions:host_windows": True,
             "//conditions:default": False,

--- a/gazelle/erlang_app.go
+++ b/gazelle/erlang_app.go
@@ -790,6 +790,7 @@ func (erlangApp *ErlangApp) CtSuiteRules(testDirBeamFilesRules []*rule.Rule) []*
 		if strings.HasSuffix(modName, "_SUITE") {
 			beamFilesRule := rulesByName[modName]
 			r := rule.NewRule(ctTestKind, modName)
+			r.SetAttr("app_name", erlangApp.Name)
 			r.SetAttr("compiled_suites",
 				append([]string{":" + beamFilesRule.Name()},
 					runtimeBeam(beamFilesRule)...))

--- a/gazelle/kinds.go
+++ b/gazelle/kinds.go
@@ -190,6 +190,7 @@ func (l *erlangLang) Kinds() map[string]rule.KindInfo {
 			},
 			SubstituteAttrs: map[string]bool{},
 			MergeableAttrs: map[string]bool{
+				"app_name":        true,
 				"compiled_suites": true,
 				"deps":            true,
 			},

--- a/private/ct.bzl
+++ b/private/ct.bzl
@@ -303,9 +303,7 @@ exit /b %CT_RUN_ERRORLEVEL%
         [
             ctx.runfiles(ctx.files.compiled_suites + ctx.files.data + erl_libs_files),
             shard_suite[DefaultInfo].default_runfiles,
-        ] + [
-            coverdata_to_lcov[DefaultInfo].default_runfiles,
-        ] if ctx.configuration.coverage_enabled else [] + [
+        ] + ([coverdata_to_lcov[DefaultInfo].default_runfiles] if ctx.configuration.coverage_enabled else []) + [
             tool[DefaultInfo].default_runfiles
             for tool in ctx.attr.tools
         ],

--- a/private/ct.bzl
+++ b/private/ct.bzl
@@ -189,7 +189,6 @@ set -x
 set +x
 if [ -n "${{COVERAGE}}" ]; then
     "{erlang_home}"/bin/escript $TEST_SRCDIR/$TEST_WORKSPACE/{coverdata_to_lcov} \\
-        {suite_name} \\
         ${{COVERAGE_OUTPUT_FILE}} \\
         ${{COVERAGE_OUTPUT_FILE}} \\
         > ${{TEST_UNDECLARED_OUTPUTS_DIR}}/coverdata_to_lcov.log

--- a/private/ct.bzl
+++ b/private/ct.bzl
@@ -191,7 +191,8 @@ if [ -n "${{COVERAGE}}" ]; then
     "{erlang_home}"/bin/escript $TEST_SRCDIR/$TEST_WORKSPACE/{coverdata_to_lcov} \\
         {suite_name} \\
         ${{COVERAGE_OUTPUT_FILE}} \\
-        ${{COVERAGE_OUTPUT_FILE}}
+        ${{COVERAGE_OUTPUT_FILE}} \\
+        > ${{TEST_UNDECLARED_OUTPUTS_DIR}}/coverdata_to_lcov.log
 fi
 """.format(
             maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),

--- a/private/erlang_bytecode2.bzl
+++ b/private/erlang_bytecode2.bzl
@@ -78,6 +78,11 @@ def _impl(ctx):
 
     (erlang_home, _, runfiles) = erlang_dirs(ctx)
 
+    instrument = (ctx.attr.testonly and
+                  (ctx.configuration.coverage_enabled and
+                   (ctx.coverage_instrumented() or
+                    any([ctx.coverage_instrumented(dep) for dep in ctx.attr.deps]))))
+
     script = """set -euo pipefail
 
 {maybe_install_erlang}
@@ -90,6 +95,11 @@ fi
     -v {include_args} {pa_args} \\
     -o {out_dir} {erlc_opts} \\
     $@
+if [ -n "{instrument}" ]; then
+    echo "Instrumenting beam files in {out_dir}..."
+    "{erlang_home}"/bin/erl -eval 'RC = case cover:compile_beam_directory("{out_dir}") of {{error, _}} -> 1; _ -> 0 end, halt(RC).' -noshell
+    echo "done"
+fi
     """.format(
         maybe_install_erlang = maybe_install_erlang(ctx),
         erlang_home = erlang_home,
@@ -98,6 +108,7 @@ fi
         pa_args = " ".join(pa_args),
         out_dir = out_dir,
         erlc_opts = " ".join(ctx.attr.erlc_opts[ErlcOptsInfo].values),
+        instrument = "1" if instrument else "",
     )
 
     inputs = depset(
@@ -118,6 +129,11 @@ fi
 
     return [
         DefaultInfo(files = depset(outputs)),
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["beam", "deps"],
+            source_attributes = ["srcs", "hdrs"],
+        ),
     ]
 
 erlang_bytecode = rule(

--- a/test/WORKSPACE.bazel
+++ b/test/WORKSPACE.bazel
@@ -1,3 +1,5 @@
+workspace(name = "rules_erlang_test")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(

--- a/test/WORKSPACE.bzlmod
+++ b/test/WORKSPACE.bzlmod
@@ -1,0 +1,29 @@
+workspace(name = "rules_erlang_test")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_buildbuddy_buildbuddy_toolchain",
+    sha256 = "a2a5cccec251211e2221b1587af2ce43c36d32a42f5d881737db3b546a536510",
+    strip_prefix = "buildbuddy-toolchain-829c8a574f706de5c96c54ca310f139f4acda7dd",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/829c8a574f706de5c96c54ca310f139f4acda7dd.tar.gz"],
+)
+
+load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
+
+buildbuddy_deps()
+
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
+
+buildbuddy(
+    name = "buildbuddy_toolchain",
+    llvm = True,
+)
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "rbe",
+    commit = "aa4d33ee8ef1410384d47035c9da8ae18c8850df",  # linux-rbe branch
+    remote = "https://github.com/rabbitmq/rbe-erlang-platform.git",
+)

--- a/test/gazelle/testdata/rebar_with_ct_suites/BUILD.out
+++ b/test/gazelle/testdata/rebar_with_ct_suites/BUILD.out
@@ -101,6 +101,7 @@ eunit(
 
 ct_test(
     name = "osiris_SUITE",
+    app_name = "rebar_with_ct_suites",
     compiled_suites = [":osiris_SUITE_beam_files"],
     data = glob(["test/osiris_SUITE_data/**/*"]),
     deps = [":test_erlang_app"],
@@ -108,6 +109,7 @@ ct_test(
 
 ct_test(
     name = "osiris_log_SUITE",
+    app_name = "rebar_with_ct_suites",
     compiled_suites = [":osiris_log_SUITE_beam_files"],
     data = glob(["test/osiris_log_SUITE_data/**/*"]),
     deps = [":test_erlang_app"],
@@ -115,6 +117,7 @@ ct_test(
 
 ct_test(
     name = "osiris_tracking_SUITE",
+    app_name = "rebar_with_ct_suites",
     compiled_suites = [":osiris_tracking_SUITE_beam_files"],
     data = glob(["test/osiris_tracking_SUITE_data/**/*"]),
     deps = [":test_erlang_app"],
@@ -122,6 +125,7 @@ ct_test(
 
 ct_test(
     name = "osiris_util_SUITE",
+    app_name = "rebar_with_ct_suites",
     compiled_suites = [":osiris_util_SUITE_beam_files"],
     data = glob(["test/osiris_util_SUITE_data/**/*"]),
     deps = [":test_erlang_app"],

--- a/tools/coverdata_to_lcov/BUILD.bazel
+++ b/tools/coverdata_to_lcov/BUILD.bazel
@@ -1,0 +1,31 @@
+load(
+    "//:erlang_bytecode2.bzl",
+    "erlang_bytecode",
+    "erlc_opts",
+)
+load(
+    "//private:escript_flat.bzl",
+    "escript_flat",
+)
+load(
+    "//:erlang_app.bzl",
+    "DEFAULT_ERLC_OPTS",
+)
+
+erlc_opts(
+    name = "erlc_opts",
+    values = DEFAULT_ERLC_OPTS,
+)
+
+erlang_bytecode(
+    name = "beam_files",
+    srcs = glob(["src/*.erl"]),
+    dest = "ebin",
+    erlc_opts = ":erlc_opts",
+)
+
+escript_flat(
+    name = "coverdata_to_lcov",
+    beam = ":beam_files",
+    visibility = ["//visibility:public"],
+)

--- a/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
+++ b/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
@@ -7,26 +7,49 @@
 -spec main([string()]) -> no_return().
 
 main([TestName, CoverdataFile, LcovFile]) ->
+    ScriptName = filename:basename(escript:script_name()),
     io:format(standard_error, "~s: converting ~s to lcov...~n",
-              [filename:basename(escript:script_name()), CoverdataFile]),
+              [ScriptName, CoverdataFile]),
+    {ok, Cwd} = file:get_cwd(),
+
     ok = cover:import(CoverdataFile),
     Modules = cover:imported_modules(),
-    {result, Ok, _Fail} = cover:analyse(Modules, calls, line),
     
     {ok, S} = file:open(LcovFile, [write]),
     io:format(S, "TN:~s~n", [TestName]),
-    %% lists:foreach(
-    %%   fun (Module) ->
-    %%           {ok, Lines} = cover:analyse(Module, calls, line),
-    %%           lists:foreach(
-    %%             fun ({{M, N}, Calls}) ->
-    %%                     io:format(standard_error, "\t~p~n", [{M, N, Calls}])
-    %%             end, Lines)
-    %%   end, Modules),
     lists:foreach(
-      fun
-          ({{M, N} = _Line, Calls}) ->
-              io:format(standard_error, "\t~p~n", [{M, N, Calls}])
-      end, Ok),
-    file:close(S),
-    halt(1).
+      fun (Module) ->
+              Path = code:which(Module),
+              io:format(S, "SF:~s~n", [Path]),
+
+              {ok, Lines} = cover:analyse(Module, calls, line),
+              {LH, LF} = lists:foldl(
+                           fun ({{_M, N}, Calls}, {LinesHit, LinesFound}) ->
+                                   case Calls of
+                                       0 ->
+                                           ok;
+                                       _ ->
+                                           RelPath = relative_path(Path, Cwd),
+                                           io:format(standard_error,
+                                                     "~s: ~s:~B calls ~B~n",
+                                                     [ScriptName, RelPath, N, Calls])
+                                   end,
+                                   io:format(S, "DA:~B,~B~n", [N, Calls]),
+                                   {LinesHit + is_hit(Calls), LinesFound + 1}
+                           end, {0, 0}, Lines),
+              io:format(S, "LH:~B~n", [LH]),
+              io:format(S, "LF:~B~n", [LF]),
+              io:format(S, "end_of_record~n", [])
+      end, Modules),
+    file:close(S).
+
+relative_path(Path, Cwd) ->
+    case string:prefix(Path, Cwd ++ "/") of
+        nomatch -> Path;
+        RelPath -> RelPath
+    end.
+
+is_hit(0) ->
+    0;
+is_hit(_) ->
+    1.

--- a/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
+++ b/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
@@ -6,7 +6,7 @@
 
 -spec main([string()]) -> no_return().
 
-main([TestName, CoverdataFile, LcovFile]) ->
+main([CoverdataFile, LcovFile]) ->
     ScriptName = filename:basename(escript:script_name()),
     io:format(standard_error, "~s: converting ~s to lcov...~n",
               [ScriptName, CoverdataFile]),
@@ -18,7 +18,6 @@ main([TestName, CoverdataFile, LcovFile]) ->
     Modules = cover:imported_modules(),
     
     {ok, S} = file:open(LcovFile, [write]),
-    io:format(S, "TN:~s~n", [TestName]),
     lists:foreach(
       fun (Module) ->
               case guess_source_file(Module, ExecRoot) of

--- a/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
+++ b/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
@@ -10,7 +10,9 @@ main([TestName, CoverdataFile, LcovFile]) ->
     ScriptName = filename:basename(escript:script_name()),
     io:format(standard_error, "~s: converting ~s to lcov...~n",
               [ScriptName, CoverdataFile]),
+
     {ok, Cwd} = file:get_cwd(),
+    {ok, ExecRoot} = find_execroot(Cwd),
 
     ok = cover:import(CoverdataFile),
     Modules = cover:imported_modules(),
@@ -19,8 +21,8 @@ main([TestName, CoverdataFile, LcovFile]) ->
     io:format(S, "TN:~s~n", [TestName]),
     lists:foreach(
       fun (Module) ->
-              Path = code:which(Module),
-              io:format(S, "SF:~s~n", [Path]),
+              {ok, SF} = guess_source_file(Module, ExecRoot),
+              io:format(S, "SF:~s~n", [SF]),
 
               {ok, Lines} = cover:analyse(Module, calls, line),
               {LH, LF} = lists:foldl(
@@ -29,10 +31,9 @@ main([TestName, CoverdataFile, LcovFile]) ->
                                        0 ->
                                            ok;
                                        _ ->
-                                           RelPath = relative_path(Path, Cwd),
                                            io:format(standard_error,
                                                      "~s: ~s:~B calls ~B~n",
-                                                     [ScriptName, RelPath, N, Calls])
+                                                     [ScriptName, SF, N, Calls])
                                    end,
                                    io:format(S, "DA:~B,~B~n", [N, Calls]),
                                    {LinesHit + is_hit(Calls), LinesFound + 1}
@@ -43,10 +44,32 @@ main([TestName, CoverdataFile, LcovFile]) ->
       end, Modules),
     file:close(S).
 
-relative_path(Path, Cwd) ->
-    case string:prefix(Path, Cwd ++ "/") of
-        nomatch -> Path;
-        RelPath -> RelPath
+find_execroot(Dir) ->
+    find_execroot(Dir, filename:dirname(Dir)).
+
+find_execroot("/", "/") ->
+    not_found;
+find_execroot(Dir, Parent) ->
+    case {filename:basename(Dir), filename:basename(Parent)} of
+        {"_main", "execroot"} ->
+            {ok, Dir};
+        _ ->
+            find_execroot(filename:dirname(Dir), filename:dirname(Parent))
+    end.
+
+guess_source_file(Module, SourceRoot) ->
+    case source_file(Module, SourceRoot, "apps") of
+        not_found ->
+            source_file(Module, SourceRoot, "deps");
+        P ->
+            P
+    end.
+
+source_file(Module, SourceRoot, AppsDir) ->
+    Pattern = filename:join([AppsDir, "*", "src", atom_to_list(Module) ++ ".erl"]),
+    case filelib:wildcard(Pattern, SourceRoot) of
+        [Path] -> {ok, Path};
+        _ -> not_found
     end.
 
 is_hit(0) ->

--- a/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
+++ b/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
@@ -1,0 +1,32 @@
+-module(coverdata_to_lcov).
+
+-mode(compile).
+
+-export([main/1]).
+
+-spec main([string()]) -> no_return().
+
+main([TestName, CoverdataFile, LcovFile]) ->
+    io:format(standard_error, "~s: converting ~s to lcov...~n",
+              [filename:basename(escript:script_name()), CoverdataFile]),
+    ok = cover:import(CoverdataFile),
+    Modules = cover:imported_modules(),
+    {result, Ok, _Fail} = cover:analyse(Modules, calls, line),
+    
+    {ok, S} = file:open(LcovFile, [write]),
+    io:format(S, "TN:~s~n", [TestName]),
+    %% lists:foreach(
+    %%   fun (Module) ->
+    %%           {ok, Lines} = cover:analyse(Module, calls, line),
+    %%           lists:foreach(
+    %%             fun ({{M, N}, Calls}) ->
+    %%                     io:format(standard_error, "\t~p~n", [{M, N, Calls}])
+    %%             end, Lines)
+    %%   end, Modules),
+    lists:foreach(
+      fun
+          ({{M, N} = _Line, Calls}) ->
+              io:format(standard_error, "\t~p~n", [{M, N, Calls}])
+      end, Ok),
+    file:close(S),
+    halt(1).


### PR DESCRIPTION
Converts erlang `cover` data to lcov so that results can be aggregated by bazel with the `--combined_report=lcov` flag. See https://bazel.build/configure/coverage#viewing_coverage for viewing combined coverage.

See https://bazel.build/configure/coverage#remote-execution for caveats using coverage with remote execution

Will not work on windows for now