### PR TITLE
Fix unbound variable error when running eunit tests without coverage

### DIFF
--- a/private/eunit.bzl
+++ b/private/eunit.bzl
@@ -113,7 +113,7 @@ def _impl(ctx):
             test_env_commands.append("export {}=\"{}\"".format(k, v))
 
         output = ctx.actions.declare_file(ctx.label.name)
-        script = """set -euo pipefail
+        script = """set -eo pipefail
 
 {maybe_install_erlang}
 


### PR DESCRIPTION
Bug was introduced in 3.13.0