### PR TITLE
Use mkdir instead of tar to lock the erlang install directory

### DIFF
--- a/tools/erlang_toolchain.bzl
+++ b/tools/erlang_toolchain.bzl
@@ -59,7 +59,7 @@ def maybe_install_erlang(ctx, short_path = False):
     else:
         return """\
 mkdir -p $(dirname "{erlang_home}")
-if [[ mkdir "{erlang_home}" ]]; then
+if mkdir "{erlang_home}"; then
     tar --extract \\
         --directory / \\
         --file {release_tar}

--- a/tools/erlang_toolchain.bzl
+++ b/tools/erlang_toolchain.bzl
@@ -58,10 +58,11 @@ def maybe_install_erlang(ctx, short_path = False):
         return ""
     else:
         return """\
-if [[ ! -d "{erlang_home}" ]]; then
+mkdir -p "$(dirname "{erlang_home}")"
+if [[ mkdir "{erlang_home}" ]]; then
     tar --extract \\
         --directory / \\
-        --file {release_tar} || test -d "{erlang_home}"
+        --file {release_tar}
 fi""".format(
             release_tar = release_dir_tar.short_path if short_path else release_dir_tar.path,
             erlang_home = info.erlang_home,

--- a/tools/erlang_toolchain.bzl
+++ b/tools/erlang_toolchain.bzl
@@ -58,7 +58,7 @@ def maybe_install_erlang(ctx, short_path = False):
         return ""
     else:
         return """\
-mkdir -p "$(dirname "{erlang_home}")"
+mkdir -p $(dirname "{erlang_home}")
 if [[ mkdir "{erlang_home}" ]]; then
     tar --extract \\
         --directory / \\


### PR DESCRIPTION
when using bazel built erlang

This should avoid flakes in situations of a reduced sandbox