### PR TITLE
OTP 26.2 compatiblity

### DIFF
--- a/test/shard_suite/test/example_suite_missing_group.erl
+++ b/test/shard_suite/test/example_suite_missing_group.erl
@@ -5,9 +5,18 @@
 
 -export([all/0, groups/0]).
 
+%% errors for missing groups are build into otp 26.2
+%% but since we test with otp 25.x as well, we can
+%% use 25.x for testing the old behaviour in
+%% rules_erlang
+-if(?OTP_RELEASE >= 25).
+all() ->
+    [{group, a_group}].
+-else.
 all() ->
     [{group, a_group},
      {group, missing_group}].
+-endif.
 
 groups() ->
     [{a_group, [], [one_test, two_test]}].

--- a/test/shard_suite/test/shard_suite_SUITE.erl
+++ b/test/shard_suite/test/shard_suite_SUITE.erl
@@ -89,5 +89,14 @@ to_ct_run_args(_) ->
                    shard_suite:to_ct_run_args(SuiteModule,
                                               shard_suite:flatten_shard(ShardThree)))).
 
+%% errors for missing groups are build into otp 26.2
+%% but since we test with otp 25.x as well, we can
+%% use 25.x for testing the old behaviour in
+%% rules_erlang
+-if(?OTP_RELEASE >= 25).
+when_all_references_missing_group(_) ->
+    ok.
+-else.
 when_all_references_missing_group(_) ->
     ?assertThrow(missing_group, shard_suite:structure(example_suite_missing_group)).
+-endif.

--- a/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
+++ b/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
@@ -61,6 +61,8 @@ find_execroot(Dir, Parent) ->
     case {filename:basename(Dir), filename:basename(Parent)} of
         {"_main", "execroot"} ->
             {ok, Dir};
+        {"_main", "bazel-working-directory"} ->
+            {ok, Dir};
         _ ->
             find_execroot(filename:dirname(Dir), filename:dirname(Parent))
     end.

--- a/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
+++ b/tools/coverdata_to_lcov/src/coverdata_to_lcov.erl
@@ -13,8 +13,7 @@ main([CoverdataFile, LcovFile]) ->
 
     AppsDirPaths = string:split(os:getenv("COVERDATA_TO_LCOV_APPS_DIRS", "apps"), ":"),
 
-    {ok, Cwd} = file:get_cwd(),
-    {ok, ExecRoot} = find_execroot(Cwd),
+    ExecRoot = os:getenv("ROOT"),
 
     ok = cover:import(CoverdataFile),
     Modules = cover:imported_modules(),
@@ -51,21 +50,6 @@ main([CoverdataFile, LcovFile]) ->
       end, Modules),
     file:close(S),
     io:format(standard_error, "~s: done.~n", [ScriptName]).
-
-find_execroot(Dir) ->
-    find_execroot(Dir, filename:dirname(Dir)).
-
-find_execroot("/", "/") ->
-    not_found;
-find_execroot(Dir, Parent) ->
-    case {filename:basename(Dir), filename:basename(Parent)} of
-        {"_main", "execroot"} ->
-            {ok, Dir};
-        {"_main", "bazel-working-directory"} ->
-            {ok, Dir};
-        _ ->
-            find_execroot(filename:dirname(Dir), filename:dirname(Parent))
-    end.
 
 guess_source_file([], _, _) ->
     not_found;


### PR DESCRIPTION
Starting in OTP 26.2, common test returns an error when a badly defined group is executed. This interferes with the way we tested test suites sharding for such tests.