### PR TITLE
Add common_root_as_var to use with nif

### DIFF
--- a/common_root_as_var.bzl
+++ b/common_root_as_var.bzl
@@ -1,0 +1,35 @@
+
+
+def _common_root_as_var(ctx):
+    if ctx.attr.var_name != "":
+        key = ctx.attr.var_name
+    else:
+        key = ctx.label.name.upper()
+
+    value = ctx.files.srcs[0].dirname
+    for src in ctx.files.srcs:
+        if value.startswith(src.dirname):
+            value = src.dirname
+        elif src.dirname.startswith(value):
+            pass
+        elif value == src.dirname:
+            pass
+        else:
+            fail("%s and %s do not share a common root" % (value, src.dirname))
+
+    return [
+        platform_common.TemplateVariableInfo({
+            key: value,
+        }),
+    ]
+
+common_root_as_var = rule(
+    implementation = _common_root_as_var,
+    attrs = {
+        "var_name": attr.string(),
+        "srcs": attr.label_list(
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
+)

--- a/util.bzl
+++ b/util.bzl
@@ -32,37 +32,3 @@ def without(item, elements):
     c = list(elements)
     c.remove(item)
     return c
-
-def _common_root_as_var(ctx):
-    if ctx.attr.var_name != "":
-        key = ctx.attr.var_name
-    else:
-        key = ctx.label.name.upper()
-
-    value = ctx.files.srcs[0].dirname
-    for src in ctx.files.srcs:
-        if value.startswith(src.dirname):
-            value = src.dirname
-        elif src.dirname.startswith(value):
-            pass
-        elif value == src.dirname:
-            pass
-        else:
-            fail("%s and %s do not share a common root" % (value, src.dirname))
-
-    return [
-        platform_common.TemplateVariableInfo({
-            key: value,
-        }),
-    ]
-
-common_root_as_var = rule(
-    implementation = _common_root_as_var,
-    attrs = {
-        "var_name": attr.string(),
-        "srcs": attr.label_list(
-            allow_files = True,
-            mandatory = True,
-        ),
-    },
-)

--- a/util.bzl
+++ b/util.bzl
@@ -32,3 +32,37 @@ def without(item, elements):
     c = list(elements)
     c.remove(item)
     return c
+
+def _common_root_as_var(ctx):
+    if ctx.attr.var_name != "":
+        key = ctx.attr.var_name
+    else:
+        key = ctx.label.name.upper()
+
+    value = ctx.files.srcs[0].dirname
+    for src in ctx.files.srcs:
+        if value.startswith(src.dirname):
+            value = src.dirname
+        elif src.dirname.startswith(value):
+            pass
+        elif value == src.dirname:
+            pass
+        else:
+            fail("%s and %s do not share a common root" % (value, src.dirname))
+
+    return [
+        platform_common.TemplateVariableInfo({
+            key: value,
+        }),
+    ]
+
+common_root_as_var = rule(
+    implementation = _common_root_as_var,
+    attrs = {
+        "var_name": attr.string(),
+        "srcs": attr.label_list(
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
+)


### PR DESCRIPTION

I saw that this function was used in multiple places https://github.com/search?q=org%3Arabbitmq+common_root_as_var+&type=code does it make sense to add it to rules_erlang so that I don't need to define it in our code?