### PR TITLE
Set use_default_shell_env for erlang_build

### DIFF
--- a/private/erlang_build.bzl
+++ b/private/erlang_build.bzl
@@ -159,6 +159,7 @@ tar --create \\
             post_configure_cmds = post_configure_cmds,
             extra_make_opts = extra_make_opts,
         ),
+        use_default_shell_env = True,
         mnemonic = "OTP",
         progress_message = "Compiling otp from source",
     )


### PR DESCRIPTION
Since we don't have a hermetic erlang build available, this makes it easier to use what's on the host