### PR TITLE
Only apply the default for app_src of erlang_app_sources if unset

### DIFF
--- a/erlang_app_sources.bzl
+++ b/erlang_app_sources.bzl
@@ -12,10 +12,10 @@ def erlang_app_sources(
         priv = None,
         license_files = None,
         **kwargs):
-
-    app_src_paths = native.glob(["src/%s.app.src" % app_name])
-    if len(app_src_paths) == 1:
-        app_src = app_src_paths[0]
+    if app_src == None:
+        app_src_paths = native.glob(["src/%s.app.src" % app_name])
+        if len(app_src_paths) == 1:
+            app_src = app_src_paths[0]
 
     if public_hdrs == None:
         public_hdrs = native.glob([

--- a/examples/basic/BUILD.bazel
+++ b/examples/basic/BUILD.bazel
@@ -44,7 +44,6 @@ erlc_opts_file(
 erlang_app_sources(
     name = "%s_srcs" % APP_NAME,
     app_name = APP_NAME,
-    app_src = ":app_src",
     erlc_opts_file = ":erlc_opts_file",
     visibility = ["//visibility:public"],
 )
@@ -52,7 +51,6 @@ erlang_app_sources(
 erlang_app_sources(
     name = "test_%s_srcs" % APP_NAME,
     app_name = APP_NAME,
-    app_src = ":app_src",
     erlc_opts_file = ":test_erlc_opts_file",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Previously the value was always overridden if the src/*.app.src file existed, which was incorrect