### PR TITLE
Corrections for Bazel Central Registry CI

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,28 +4,30 @@ shell_commands: &shell_commands
 - ./kerl update releases
 - ./kerl build ${ERLANG_VERSION}
 - ./kerl install ${ERLANG_VERSION} ~/kerl/${ERLANG_VERSION}
-- realpath ~/kerl/${ERLANG_VERSION}
 
 matrix:
   bazel:
-  - 6.x
   - 7.x
-platforms:
-  macos:
+tasks:
+  verify_targets_macos:
+    name: Verify build targets (macos)
+    platform: macos
+    bazel: ${{ bazel }}
     environment:
       ERLANG_VERSION: "26.2"
       ERLANG_HOME: /Users/buildkite/kerl/26.2
-    bazel: ${{ bazel }}
     shell_commands: *shell_commands
     build_flags:
     - --incompatible_strict_action_env
     build_targets:
     - '@rules_erlang//...'
-  ubuntu2004:
+  verify_targets_ubuntu:
+    name: Verify build targets (ubuntu2004)
+    platform: ubuntu2004
+    bazel: ${{ bazel }}
     environment:
       ERLANG_VERSION: "26.2"
       ERLANG_HOME: /var/lib/buildkite-agent/kerl/26.2
-    bazel: ${{ bazel }}
     shell_commands: *shell_commands
     build_flags:
     - --incompatible_strict_action_env

--- a/private/app_file_test.bzl
+++ b/private/app_file_test.bzl
@@ -6,10 +6,9 @@ def _app_file_test_impl(ctx):
     env = analysistest.begin(ctx)
 
     target_under_test = analysistest.target_under_test(env)
-    asserts.equals(
+    asserts.true(
         env,
-        expected = path_join(ctx.label.package, "basic.app"),
-        actual = target_under_test[DefaultInfo].files.to_list()[0].short_path,
+        target_under_test[DefaultInfo].files.to_list()[0].short_path.endswith(path_join(ctx.label.package, "basic.app")),
     )
 
     return analysistest.end(env)


### PR DESCRIPTION
- Fix a test that fails incorrectly when rules_erlang is not the main repo
- Update the BCR presubmit.yml based on newer expectations in the BCR CI